### PR TITLE
fix: drop `fontWeight` besides `bold`

### DIFF
--- a/config/typography.js
+++ b/config/typography.js
@@ -21,11 +21,8 @@ const fontSize = {
 };
 
 const fontWeight = {
-  thin: 200,
-  light: 300,
   normal: 400,
-  semibold: 600,
-  extrabold: 800
+  bold: 600
 };
 
 const letterSpacing = {

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -6,6 +6,10 @@ module.exports = function fluidTailwindPlugin({ addBase, theme }) {
       fontFamily: theme('fontFamily.sans').reduce((acc, font) => `${acc}, ${font}`)
     },
 
+    'b, strong': {
+      fontWeight: theme('fontWeight.bold')
+    },
+
     'input, textarea': {
       '&::placeholder': {
         color: theme('colors.neutral.500')

--- a/stories/Font/weight.stories.js
+++ b/stories/Font/weight.stories.js
@@ -2,24 +2,19 @@ import { LoremIpsum } from 'lorem-ipsum';
 
 const lorem = new LoremIpsum();
 
-function makeFontWeightStory(size) {
-  return `
-    <h2><pre>.font-${size}</pre></h2>
-    <p class="font-${size}">${lorem.generateParagraphs(1)}</p>
-  `;
-}
-
 export default {
   title: 'Font|Weight',
   decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
 };
 
-export const Thin = () => makeFontWeightStory('thin');
+export const Normal = () => `
+  <h2><pre>.font-normal</pre></h2>
+  <p class="font-normal">${lorem.generateParagraphs(1)}</p>
+`;
 
-export const Light = () => makeFontWeightStory('light');
-
-export const Normal = () => makeFontWeightStory('normal');
-
-export const SemiBold = () => makeFontWeightStory('semibold');
-
-export const ExtraBold = () => makeFontWeightStory('extrabold');
+export const Bold = () => `
+  <h2><pre>.font-bold</pre></h2>
+  <p class="font-bold" style="margin-bottom: 16px">${lorem.generateParagraphs(1)}</p>
+  <h2><pre>&lt;strong&gt;</pre></h2>
+  <strong>${lorem.generateParagraphs(1)}</strong>
+`;


### PR DESCRIPTION
Following discussion today, it was decided that we only need to define
a single weight (besides `normal`), `bold`, which would use the `600`
weight that is recommended by the brand team (instead of the default
`700`).

This allows developers to ignore the fact that we technically never want
to use "bold", and instead always want "semibold".

We also style the semantic `b` and `strong` elements with the correct
weight.