### PR TITLE
Fix line height to match expectations 

### DIFF
--- a/config/typography.js
+++ b/config/typography.js
@@ -34,6 +34,7 @@ const letterSpacing = {
 };
 
 const lineHeight = {
+  none: 1,
   '2xs': '1rem',
   xs: '1.25rem',
   sm: '1.5rem',

--- a/config/typography.js
+++ b/config/typography.js
@@ -34,15 +34,15 @@ const letterSpacing = {
 };
 
 const lineHeight = {
-  '2xs': 1,
-  xs: 1.25,
-  sm: 1.5,
-  base: 1.75,
-  md: 2,
-  lg: 2.25,
-  xl: 2.5,
-  '2xl': 2.75,
-  '3xl': 3.5
+  '2xs': '1rem',
+  xs: '1.25rem',
+  sm: '1.5rem',
+  base: '1.75rem',
+  md: '2rem',
+  lg: '2.25rem',
+  xl: '2.5rem',
+  '2xl': '2.75rem',
+  '3xl': '3.5rem'
 };
 
 module.exports = {

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -2,7 +2,7 @@
 
 module.exports = function fluidTailwindPlugin({ addBase, theme }) {
   addBase({
-    html: {
+    'html, body': {
       // Default to our normal text color
       color: theme('colors.neutral.900'),
       // Default to using our `sans` font family

--- a/stories/Utilities/Font/line-height.stories.js
+++ b/stories/Utilities/Font/line-height.stories.js
@@ -17,6 +17,12 @@ export default {
   decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
 };
 
+export const None = () =>
+  makeLineHeightStory(
+    'none',
+    'Match the line height to the font size, no matter what the font size is'
+  );
+
 export const ExtraExtraSmall = () =>
   makeLineHeightStory('2xs', 'Use sparingly. Caption text only.');
 


### PR DESCRIPTION
I think that the intended values for `line-height` and the way that it got implemented ended up slightly out-of-sync, due to the difference between a `line-height` value without a unit and using `rem`.

The documentation in Notion lists values without units, but the way that it's described, it seems like what we actually want is to use a `rem` unit for the values.