### PR TITLE
feat: enable max/min height/width plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,6 @@ module.exports = {
   ],
   corePlugins: {
     height: false,
-    maxHeight: false,
-    maxWidth: false,
-    minHeight: false,
-    minWidth: false,
     width: false
   }
 };

--- a/tests/no-size-classes.js
+++ b/tests/no-size-classes.js
@@ -18,10 +18,7 @@ async function parse(filePath) {
 test('there are no height classes', async t => {
   const ast = await parse('../dist/fluid-tailwind.css');
   const rules = ast.nodes.filter(node => node.type === 'rule');
-  const heightRules = rules.filter(
-    ({ selector }) =>
-      selector.startsWith('.h-') || selector.startsWith('.max-h-') || selector.startsWith('.min-h-')
-  );
+  const heightRules = rules.filter(({ selector }) => selector.startsWith('.h-'));
 
   t.is(heightRules.length, 0);
 });
@@ -29,10 +26,7 @@ test('there are no height classes', async t => {
 test('there are no width classes', async t => {
   const ast = await parse('../dist/fluid-tailwind.css');
   const rules = ast.nodes.filter(node => node.type === 'rule');
-  const widthRules = rules.filter(
-    ({ selector }) =>
-      selector.startsWith('.w-') || selector.startsWith('.max-w-') || selector.startsWith('.min-w-')
-  );
+  const widthRules = rules.filter(({ selector }) => selector.startsWith('.w-'));
 
   t.is(widthRules.length, 0);
 });


### PR DESCRIPTION
The max- and min- height and width plugins from Tailwind actually are not configured based on a scale at all. 

Because of this, it's really unlikely that we would have an opinion on what sizes are made available
to use with them. They should be safe for us to enable even before we have the actual height/width size scale defined.

Related to #22 