### PR TITLE
Add CodePen template link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Verify](https://github.com/movableink/tailwind-config/workflows/Verify/badge.svg)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/movableink/tailwind-config)
+[![Create CodePen with Template](https://img.shields.io/badge/CodePen-Use%20Template-yellow)](https://codepen.io/pen?template=jOPWJdW)
 
 > [Tailwind][tailwind] configuration file for Movable Ink's Fluid Design System
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you want to go even _simpler_, you can link against the pre-built CSS file on
 ```html
 <link
   rel="stylesheet"
-  href="http://unpkg.com/@movable/tailwind-config/dist/fluid-tailwind.min.css"
+  href="https://unpkg.com/@movable/tailwind-config/dist/fluid-tailwind.min.css"
 />
 ```
 


### PR DESCRIPTION
@keser asked me about whether we could have a static build of Tailwind somewhere, so we can use CodePen (or anything else) as a playground for prototyping things with our Tailwind configuration.

Since we already have that static build, I went and created a CodePen template that includes the links to the Google Fonts and Tailwind build on `unpkg`.

This adds a badge to our README that will create a new CodePen for you with that template. It also updates the `unpkg` URL to use `https`; CodePen warned about the original `http` link.