### PR TITLE
Only report file size to PR if changed

### DIFF
--- a/.github/workflows/report-file-size.yml
+++ b/.github/workflows/report-file-size.yml
@@ -84,6 +84,7 @@ jobs:
           echo "::set-output name=minified::$(du -k pr-dist/fluid-tailwind.min.css | cut -f1)"
           echo "::set-output name=gzip::$(du -k pr-dist/fluid-tailwind.min.css.gz | cut -f1)"
       - name: Post Comment
+        if: steps.master-size.outputs.base != steps.pr-size.outputs.base
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To avoid the comments from the GitHub Actions bot getting annoying, when the file sizes had no change, it now only actually reports the file sizes if the _base_ `fluid-tailwind.css` file has a different size.