### PR TITLE
Revert "feat: generate classes with `!important`"

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const headingTextComponentsPlugin = require('./plugins/components/heading-text')
  * Configures Tailwind to use Fluid's design tokens
  */
 module.exports = {
-  important: true,
   theme: {
     colors,
     fill: colors,


### PR DESCRIPTION
This reverts commit 3ea23d75fbf09f062be03e55129a27a48dba4fc7.

***

Adding `!important` caused a lot of breaking changes in Canvas, and I think is overall too dangerous of a move.

Not including it will just mean that we have to be more diligent about removing "old" styles as we transition to Tailwind.