### PR TITLE
Docs Site Improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,9 @@
       "parserOptions": {
         "sourceType": "module"
       },
+      "env": {
+        "browser": true
+      },
       "rules": {
         "node/no-unsupported-features/es-syntax": "off"
       }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dependencies and Build Stylesheets
         run: yarn install
       - name: Build Storybook
-        run: yarn build-storybook -s dist
+        run: yarn build-storybook -s dist,node_modules/prismjs/themes
       - name: Upload to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Code+Pro:400,600&display=swap">
+<link rel="stylesheet" href="./prism.css">
 <link rel="stylesheet" href="./fluid-tailwind.css">
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -15,6 +15,9 @@ addDecorator(storyFn => {
     result = html([result]);
   }
 
-  return render(result);
+  const rendered = render(result);
+
+  // Avoid printing serialization code for `<`
+  return rendered.replace(/&amp;/g, '&');
 });
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,20 @@
+import { addDecorator } from '@storybook/html'
+import { html } from 'htm/preact';
+import render from 'preact-render-to-string';
+
+addDecorator(storyFn => html`
+  <div class="p-4 bg-white h-screen">
+    ${storyFn()}
+  </div>
+`);
+
+addDecorator(storyFn => {
+  let result = storyFn();
+
+  if (typeof result === 'string') {
+    result = html([result]);
+  }
+
+  return render(result);
+});
+

--- a/package.json
+++ b/package.json
@@ -35,10 +35,13 @@
     "babel-loader": "^8.0.6",
     "csso-cli": "^3.0.0",
     "eslint-plugin-ava": "^10.0.0",
+    "htm": "^3.0.3",
     "husky": "^4.2.1",
     "lint-staged": "^10.0.7",
     "lorem-ipsum": "^2.0.3",
     "postcss": "^7.0.24",
+    "preact": "^10.3.2",
+    "preact-render-to-string": "^5.1.4",
     "seedrandom": "^3.0.5",
     "standard-version": "^7.0.1",
     "tailwindcss": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tailwind build css/tailwind-imports.css --config index.js -o dist/fluid-tailwind.css",
     "compress": "csso dist/fluid-tailwind.css --output dist/fluid-tailwind.min.css --source-map file --no-restructure",
-    "start": "start-storybook -s dist",
+    "start": "start-storybook -s dist,node_modules/prismjs/themes",
     "lint": "eslint .",
     "pretest": "yarn build",
     "test": "ava",
@@ -42,6 +42,7 @@
     "postcss": "^7.0.24",
     "preact": "^10.3.2",
     "preact-render-to-string": "^5.1.4",
+    "prismjs": "^1.19.0",
     "seedrandom": "^3.0.5",
     "standard-version": "^7.0.1",
     "tailwindcss": "^1.1.4"

--- a/stories/Components/BodyText/cookbook.stories.js
+++ b/stories/Components/BodyText/cookbook.stories.js
@@ -1,6 +1,6 @@
 export default {
   title: 'Components/Body Text|Cookbook',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const OverridingFontWeight = () => `

--- a/stories/Components/BodyText/cookbook.stories.js
+++ b/stories/Components/BodyText/cookbook.stories.js
@@ -1,9 +1,10 @@
+import { html } from 'htm/preact';
+
 export default {
-  title: 'Components/Body Text|Cookbook',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Components/Body Text|Cookbook'
 };
 
-export const OverridingFontWeight = () => `
+export const OverridingFontWeight = () => html`
   <p class="body-base font-bold">
     Base body class, but with bold text
   </p>

--- a/stories/Components/BodyText/cookbook.stories.js
+++ b/stories/Components/BodyText/cookbook.stories.js
@@ -1,11 +1,14 @@
 import { html } from 'htm/preact';
+import Example from '../../_utils/Example';
 
 export default {
   title: 'Components/Body Text|Cookbook'
 };
 
 export const OverridingFontWeight = () => html`
-  <p class="body-base font-bold">
-    Base body class, but with bold text
-  </p>
+  <${Example}>
+    <p class="body-base font-bold">
+      Base body class, but with bold text
+    </p>
+  </>
 `;

--- a/stories/Components/BodyText/index.stories.js
+++ b/stories/Components/BodyText/index.stories.js
@@ -1,18 +1,18 @@
 import { LoremIpsum } from 'lorem-ipsum';
+import { html } from 'htm/preact';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeBodyTextStory(size) {
-  return `
+  return html`
     <h2><pre>.body-${size}</pre></h2>
     <p class="body-${size}">${lorem.generateParagraphs(1)}</p>
   `;
 }
 
 export default {
-  title: 'Components|Body Text',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Components|Body Text'
 };
 
 export const Small = () => makeBodyTextStory('sm');

--- a/stories/Components/BodyText/index.stories.js
+++ b/stories/Components/BodyText/index.stories.js
@@ -1,13 +1,17 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
+import Example from '../../_utils/Example';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeBodyTextStory(size) {
   return html`
-    <h2><pre>.body-${size}</pre></h2>
-    <p class="body-${size}">${lorem.generateParagraphs(1)}</p>
+    <${Example}>
+      <p class="body-${size}">
+        ${lorem.generateParagraphs(1)}
+      </p>
+    </>
   `;
 }
 

--- a/stories/Components/BodyText/index.stories.js
+++ b/stories/Components/BodyText/index.stories.js
@@ -12,7 +12,7 @@ function makeBodyTextStory(size) {
 
 export default {
   title: 'Components|Body Text',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const Small = () => makeBodyTextStory('sm');

--- a/stories/Components/CaptionText.stories.js
+++ b/stories/Components/CaptionText.stories.js
@@ -1,18 +1,18 @@
 import { LoremIpsum } from 'lorem-ipsum';
+import { html } from 'htm/preact';
 import random from '../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeCaptionTextStory(size) {
-  return `
+  return html`
     <h2><pre>.caption-${size}</pre></h2>
     <p class="caption-${size}">${lorem.generateParagraphs(1)}</p>
   `;
 }
 
 export default {
-  title: 'Components|Caption Text',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Components|Caption Text'
 };
 
 export const Small = () => makeCaptionTextStory('sm');

--- a/stories/Components/CaptionText.stories.js
+++ b/stories/Components/CaptionText.stories.js
@@ -1,13 +1,15 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
+import Example from '../_utils/Example';
 import random from '../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeCaptionTextStory(size) {
   return html`
-    <h2><pre>.caption-${size}</pre></h2>
-    <p class="caption-${size}">${lorem.generateParagraphs(1)}</p>
+    <${Example}>
+      <p class="caption-${size}">${lorem.generateParagraphs(1)}</p>
+    </>
   `;
 }
 

--- a/stories/Components/CaptionText.stories.js
+++ b/stories/Components/CaptionText.stories.js
@@ -12,7 +12,7 @@ function makeCaptionTextStory(size) {
 
 export default {
   title: 'Components|Caption Text',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const Small = () => makeCaptionTextStory('sm');

--- a/stories/Components/HeadingText.stories.js
+++ b/stories/Components/HeadingText.stories.js
@@ -18,7 +18,7 @@ function makeHeadingTextStory(size) {
 
 export default {
   title: 'Components|Heading Text',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const ExtraSmall = () => makeHeadingTextStory('xs');

--- a/stories/Components/HeadingText.stories.js
+++ b/stories/Components/HeadingText.stories.js
@@ -1,4 +1,5 @@
 import { LoremIpsum } from 'lorem-ipsum';
+import { html } from 'htm/preact';
 import random from '../_utils/random';
 
 const lorem = new LoremIpsum({
@@ -10,15 +11,14 @@ const lorem = new LoremIpsum({
 });
 
 function makeHeadingTextStory(size) {
-  return `
+  return html`
     <h2><pre>.heading-${size}</pre></h2>
     <p class="heading-${size}">${lorem.generateSentences(1)}</p>
   `;
 }
 
 export default {
-  title: 'Components|Heading Text',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Components|Heading Text'
 };
 
 export const ExtraSmall = () => makeHeadingTextStory('xs');

--- a/stories/Components/HeadingText.stories.js
+++ b/stories/Components/HeadingText.stories.js
@@ -1,5 +1,6 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
+import Example from '../_utils/Example';
 import random from '../_utils/random';
 
 const lorem = new LoremIpsum({
@@ -12,8 +13,9 @@ const lorem = new LoremIpsum({
 
 function makeHeadingTextStory(size) {
   return html`
-    <h2><pre>.heading-${size}</pre></h2>
-    <p class="heading-${size}">${lorem.generateSentences(1)}</p>
+    <${Example}>
+      <p class="heading-${size}">${lorem.generateSentences(1)}</p>
+    </>
   `;
 }
 

--- a/stories/Guides/color.stories.js
+++ b/stories/Guides/color.stories.js
@@ -1,14 +1,17 @@
 import { html } from 'htm/preact';
+import Code from '../_utils/InlineCode';
 
 export default {
   title: 'Guides|Color'
 };
 
-function Cell({ color, value }) {
+function Cell({ color, value, className = value && value > 400 ? 'text-white' : '' }) {
+  const identifier = value ? `${color}-${value}` : color;
+
   return html`
-    <div class="flex items-center justify-center bg-${color}-${value}">
-      <code class="text-sm ${value > 400 ? 'text-white' : ''}">
-        ${color}-${value}
+    <div class="flex items-center justify-center bg-${identifier} ${className}">
+      <code class="text-sm">
+        ${identifier}
       </code>
     </div>
   `;
@@ -97,5 +100,75 @@ export const Palette = () => html`
     <${Cell} color="violet" value="500" />
     <${Cell} color="violet" value="600" />
     <${Cell} color="violet" value="700" />
+  </div>
+`;
+
+export const Aliases = () => html`
+  <h1 class="heading-md mb-2">Color Aliases</h1>
+
+  <p class="body-base mb-2">
+    Each of our core colors has a alias, or shortcut, that can be used to avoid needing to provide
+    the color's numerical value.
+  </p>
+
+  <p class="body-base mb-2">
+    Each color's alias corresponds to the "middle" step for the range of values. For most colors,
+    this matches the <${Code}>400</> value. For <${Code}>neutral</> however, it matches the <${Code}>500</> value.
+  </p>
+
+  <p class="body-base mb-2">
+    Additionally, an alias for <${Code}>black</> and <${Code}>white</> are provided.
+  </p>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div class="grid grid-cols-2 gap-px h-24 bg-neutral-300 border border-neutral-300">
+      <${Cell} color="neutral" value="100" />
+      <${Cell} color="white" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="neutral" value="500" className="text-black" />
+      <${Cell} color="neutral" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="red" value="400" />
+      <${Cell} color="red" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="orange" value="400" />
+      <${Cell} color="orange" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="yellow" value="400" />
+      <${Cell} color="yellow" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="green" value="400" />
+      <${Cell} color="green" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="aqua" value="400" />
+      <${Cell} color="aqua" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="blue" value="400" />
+      <${Cell} color="blue" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="violet" value="400" />
+      <${Cell} color="violet" />
+    </div>
+
+    <div class="grid grid-cols-2 gap-px h-24">
+      <${Cell} color="neutral" value="900" />
+      <${Cell} color="black" className="text-white" />
+    </div>
   </div>
 `;

--- a/stories/Guides/palette.stories.js
+++ b/stories/Guides/palette.stories.js
@@ -1,10 +1,11 @@
+import { html } from 'htm/preact';
+
 export default {
-  title: 'Guides|Color',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Guides|Color'
 };
 
-function Cell(color, value) {
-  return `
+function Cell({ color, value }) {
+  return html`
     <div class="flex items-center justify-center bg-${color}-${value}">
       <code class="text-sm ${value > 400 ? 'text-white' : ''}">
         ${color}-${value}
@@ -13,88 +14,88 @@ function Cell(color, value) {
   `;
 }
 
-export const Palette = () => `
+export const Palette = () => html`
   <h1 class="heading-md mb-2">Color Palette</h1>
 
   <div class="grid grid-cols-9 h-24 mb-4">
-    ${Cell('neutral', 100)}
-    ${Cell('neutral', 200)}
-    ${Cell('neutral', 300)}
-    ${Cell('neutral', 400)}
-    ${Cell('neutral', 500)}
-    ${Cell('neutral', 600)}
-    ${Cell('neutral', 700)}
-    ${Cell('neutral', 800)}
-    ${Cell('neutral', 900)}
+    <${Cell} color="neutral" value="100" />
+    <${Cell} color="neutral" value="200" />
+    <${Cell} color="neutral" value="300" />
+    <${Cell} color="neutral" value="400" />
+    <${Cell} color="neutral" value="500" />
+    <${Cell} color="neutral" value="600" />
+    <${Cell} color="neutral" value="700" />
+    <${Cell} color="neutral" value="800" />
+    <${Cell} color="neutral" value="900" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('red', 100)}
-    ${Cell('red', 200)}
-    ${Cell('red', 300)}
-    ${Cell('red', 400)}
-    ${Cell('red', 500)}
-    ${Cell('red', 600)}
-    ${Cell('red', 700)}
+    <${Cell} color="red" value="100" />
+    <${Cell} color="red" value="200" />
+    <${Cell} color="red" value="300" />
+    <${Cell} color="red" value="400" />
+    <${Cell} color="red" value="500" />
+    <${Cell} color="red" value="600" />
+    <${Cell} color="red" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('orange', 100)}
-    ${Cell('orange', 200)}
-    ${Cell('orange', 300)}
-    ${Cell('orange', 400)}
-    ${Cell('orange', 500)}
-    ${Cell('orange', 600)}
-    ${Cell('orange', 700)}
+    <${Cell} color="orange" value="100" />
+    <${Cell} color="orange" value="200" />
+    <${Cell} color="orange" value="300" />
+    <${Cell} color="orange" value="400" />
+    <${Cell} color="orange" value="500" />
+    <${Cell} color="orange" value="600" />
+    <${Cell} color="orange" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('yellow', 100)}
-    ${Cell('yellow', 200)}
-    ${Cell('yellow', 300)}
-    ${Cell('yellow', 400)}
-    ${Cell('yellow', 500)}
-    ${Cell('yellow', 600)}
-    ${Cell('yellow', 700)}
+    <${Cell} color="yellow" value="100" />
+    <${Cell} color="yellow" value="200" />
+    <${Cell} color="yellow" value="300" />
+    <${Cell} color="yellow" value="400" />
+    <${Cell} color="yellow" value="500" />
+    <${Cell} color="yellow" value="600" />
+    <${Cell} color="yellow" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('green', 100)}
-    ${Cell('green', 200)}
-    ${Cell('green', 300)}
-    ${Cell('green', 400)}
-    ${Cell('green', 500)}
-    ${Cell('green', 600)}
-    ${Cell('green', 700)}
+    <${Cell} color="green" value="100" />
+    <${Cell} color="green" value="200" />
+    <${Cell} color="green" value="300" />
+    <${Cell} color="green" value="400" />
+    <${Cell} color="green" value="500" />
+    <${Cell} color="green" value="600" />
+    <${Cell} color="green" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('aqua', 100)}
-    ${Cell('aqua', 200)}
-    ${Cell('aqua', 300)}
-    ${Cell('aqua', 400)}
-    ${Cell('aqua', 500)}
-    ${Cell('aqua', 600)}
-    ${Cell('aqua', 700)}
+    <${Cell} color="aqua" value="100" />
+    <${Cell} color="aqua" value="200" />
+    <${Cell} color="aqua" value="300" />
+    <${Cell} color="aqua" value="400" />
+    <${Cell} color="aqua" value="500" />
+    <${Cell} color="aqua" value="600" />
+    <${Cell} color="aqua" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('blue', 100)}
-    ${Cell('blue', 200)}
-    ${Cell('blue', 300)}
-    ${Cell('blue', 400)}
-    ${Cell('blue', 500)}
-    ${Cell('blue', 600)}
-    ${Cell('blue', 700)}
+    <${Cell} color="blue" value="100" />
+    <${Cell} color="blue" value="200" />
+    <${Cell} color="blue" value="300" />
+    <${Cell} color="blue" value="400" />
+    <${Cell} color="blue" value="500" />
+    <${Cell} color="blue" value="600" />
+    <${Cell} color="blue" value="700" />
   </div>
 
   <div class="grid grid-cols-7 h-24 mb-4">
-    ${Cell('violet', 100)}
-    ${Cell('violet', 200)}
-    ${Cell('violet', 300)}
-    ${Cell('violet', 400)}
-    ${Cell('violet', 500)}
-    ${Cell('violet', 600)}
-    ${Cell('violet', 700)}
+    <${Cell} color="violet" value="100" />
+    <${Cell} color="violet" value="200" />
+    <${Cell} color="violet" value="300" />
+    <${Cell} color="violet" value="400" />
+    <${Cell} color="violet" value="500" />
+    <${Cell} color="violet" value="600" />
+    <${Cell} color="violet" value="700" />
   </div>
 `;

--- a/stories/Utilities/Color/text.stories.js
+++ b/stories/Utilities/Color/text.stories.js
@@ -1,11 +1,14 @@
 import { html } from 'htm/preact';
+import Example from '../../_utils/Example';
 
 export default {
   title: 'Utilities|Color/Text'
 };
 
 export const ChangeOnHover = () => html`
-  <p class="text-red hover:text-blue">
-    Hover me for blue text!
-  </p>
+  <${Example}>
+    <p class="text-red hover:text-blue">
+      Hover me for blue text!
+    </p>
+  </>
 `;

--- a/stories/Utilities/Color/text.stories.js
+++ b/stories/Utilities/Color/text.stories.js
@@ -1,6 +1,6 @@
 export default {
   title: 'Utilities|Color/Text',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const ChangeOnHover = () => `

--- a/stories/Utilities/Color/text.stories.js
+++ b/stories/Utilities/Color/text.stories.js
@@ -1,9 +1,10 @@
+import { html } from 'htm/preact';
+
 export default {
-  title: 'Utilities|Color/Text',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Utilities|Color/Text'
 };
 
-export const ChangeOnHover = () => `
+export const ChangeOnHover = () => html`
   <p class="text-red hover:text-blue">
     Hover me for blue text!
   </p>

--- a/stories/Utilities/Font/letter-spacing.stories.js
+++ b/stories/Utilities/Font/letter-spacing.stories.js
@@ -1,20 +1,20 @@
 import { LoremIpsum } from 'lorem-ipsum';
-import makeCallout from '../../_utils/callout';
+import { html } from 'htm/preact';
+import Callout from '../../_utils/Callout';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeLetterSpacingStory(size, notes) {
-  return `
+  return html`
     <h2><pre>.tracking-${size}</pre></h2>
-    ${notes ? makeCallout(notes) : ''}
+    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
     <p class="tracking-${size}">${lorem.generateParagraphs(1)}</p>
   `;
 }
 
 export default {
-  title: 'Utilities|Font/Letter Spacing',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Utilities|Font/Letter Spacing'
 };
 
 export const ExtraExtraSmall = () =>

--- a/stories/Utilities/Font/letter-spacing.stories.js
+++ b/stories/Utilities/Font/letter-spacing.stories.js
@@ -14,7 +14,7 @@ function makeLetterSpacingStory(size, notes) {
 
 export default {
   title: 'Utilities|Font/Letter Spacing',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const ExtraExtraSmall = () =>

--- a/stories/Utilities/Font/letter-spacing.stories.js
+++ b/stories/Utilities/Font/letter-spacing.stories.js
@@ -1,15 +1,16 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
-import Callout from '../../_utils/Callout';
+import Example from '../../_utils/Example';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeLetterSpacingStory(size, notes) {
   return html`
-    <h2><pre>.tracking-${size}</pre></h2>
-    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
-    <p class="tracking-${size}">${lorem.generateParagraphs(1)}</p>
+    <p class="mb-4">${notes}</p>
+    <${Example}>
+      <p class="tracking-${size}">${lorem.generateParagraphs(1)}</p>
+    </>
   `;
 }
 

--- a/stories/Utilities/Font/line-height.stories.js
+++ b/stories/Utilities/Font/line-height.stories.js
@@ -1,15 +1,16 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
-import Callout from '../../_utils/Callout';
+import Example from '../../_utils/Example';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeLineHeightStory(size, notes) {
   return html`
-    <h2><pre>.leading-${size}</pre></h2>
-    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
-    <p class="leading-${size}">${lorem.generateParagraphs(1)}</p>
+    <p class="mb-4">${notes}</p>
+    <${Example}>
+      <p class="leading-${size}">${lorem.generateParagraphs(1)}</p>A
+    </>
   `;
 }
 

--- a/stories/Utilities/Font/line-height.stories.js
+++ b/stories/Utilities/Font/line-height.stories.js
@@ -1,20 +1,20 @@
 import { LoremIpsum } from 'lorem-ipsum';
-import makeCallout from '../../_utils/callout';
+import { html } from 'htm/preact';
+import Callout from '../../_utils/Callout';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeLineHeightStory(size, notes) {
-  return `
+  return html`
     <h2><pre>.leading-${size}</pre></h2>
-    ${notes ? makeCallout(notes) : ''}
+    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
     <p class="leading-${size}">${lorem.generateParagraphs(1)}</p>
   `;
 }
 
 export default {
-  title: 'Utilities|Font/Line Height',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Utilities|Font/Line Height'
 };
 
 export const None = () =>

--- a/stories/Utilities/Font/line-height.stories.js
+++ b/stories/Utilities/Font/line-height.stories.js
@@ -14,7 +14,7 @@ function makeLineHeightStory(size, notes) {
 
 export default {
   title: 'Utilities|Font/Line Height',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const None = () =>

--- a/stories/Utilities/Font/size.stories.js
+++ b/stories/Utilities/Font/size.stories.js
@@ -14,7 +14,7 @@ function makeFontSizeStory(size, notes) {
 
 export default {
   title: 'Utilities|Font/Size',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const Minor3 = () =>

--- a/stories/Utilities/Font/size.stories.js
+++ b/stories/Utilities/Font/size.stories.js
@@ -1,15 +1,16 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
-import Callout from '../../_utils/Callout';
+import Example from '../../_utils/Example';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeFontSizeStory(size, notes) {
   return html`
-    <h2><pre>.text-${size}</pre></h2>
-    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
-    <p class="text-${size}">${lorem.generateParagraphs(1)}</p>
+    <p class="mb-4">${notes}</p>
+    <${Example}>
+      <p class="text-${size}">${lorem.generateParagraphs(1)}</p>
+    </>
   `;
 }
 

--- a/stories/Utilities/Font/size.stories.js
+++ b/stories/Utilities/Font/size.stories.js
@@ -1,20 +1,20 @@
 import { LoremIpsum } from 'lorem-ipsum';
-import makeCallout from '../../_utils/callout';
+import { html } from 'htm/preact';
+import Callout from '../../_utils/Callout';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 function makeFontSizeStory(size, notes) {
-  return `
+  return html`
     <h2><pre>.text-${size}</pre></h2>
-    ${notes ? makeCallout(notes) : ''}
+    ${notes ? html`<${Callout}>${notes}</Callout>` : ''}
     <p class="text-${size}">${lorem.generateParagraphs(1)}</p>
   `;
 }
 
 export default {
-  title: 'Utilities|Font/Size',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Utilities|Font/Size'
 };
 
 export const Minor3 = () =>

--- a/stories/Utilities/Font/weight.stories.js
+++ b/stories/Utilities/Font/weight.stories.js
@@ -5,7 +5,7 @@ const lorem = new LoremIpsum({ random });
 
 export default {
   title: 'Utilities|Font/Weight',
-  decorators: [storyFn => `<div style="margin: 16px">${storyFn()}</div>`]
+  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
 };
 
 export const Normal = () => `

--- a/stories/Utilities/Font/weight.stories.js
+++ b/stories/Utilities/Font/weight.stories.js
@@ -1,21 +1,21 @@
 import { LoremIpsum } from 'lorem-ipsum';
+import { html } from 'htm/preact';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
 
 export default {
-  title: 'Utilities|Font/Weight',
-  decorators: [storyFn => `<div class="m-4">${storyFn()}</div>`]
+  title: 'Utilities|Font/Weight'
 };
 
-export const Normal = () => `
+export const Normal = () => html`
   <h2><pre>.font-normal</pre></h2>
   <p class="font-normal">${lorem.generateParagraphs(1)}</p>
 `;
 
-export const Bold = () => `
+export const Bold = () => html`
   <h2><pre>.font-bold</pre></h2>
-  <p class="font-bold" style="margin-bottom: 16px">${lorem.generateParagraphs(1)}</p>
+  <p class="font-bold mb-4">${lorem.generateParagraphs(1)}</p>
   <h2><pre>&lt;strong&gt;</pre></h2>
   <strong>${lorem.generateParagraphs(1)}</strong>
 `;

--- a/stories/Utilities/Font/weight.stories.js
+++ b/stories/Utilities/Font/weight.stories.js
@@ -1,5 +1,6 @@
 import { LoremIpsum } from 'lorem-ipsum';
 import { html } from 'htm/preact';
+import Example from '../../_utils/Example';
 import random from '../../_utils/random';
 
 const lorem = new LoremIpsum({ random });
@@ -9,13 +10,16 @@ export default {
 };
 
 export const Normal = () => html`
-  <h2><pre>.font-normal</pre></h2>
-  <p class="font-normal">${lorem.generateParagraphs(1)}</p>
+  <${Example}>
+    <p class="font-normal">${lorem.generateParagraphs(1)}</p>
+  </>
 `;
 
 export const Bold = () => html`
-  <h2><pre>.font-bold</pre></h2>
-  <p class="font-bold mb-4">${lorem.generateParagraphs(1)}</p>
-  <h2><pre>&lt;strong&gt;</pre></h2>
-  <strong>${lorem.generateParagraphs(1)}</strong>
+  <${Example} className="mb-4">
+    <p class="font-bold">${lorem.generateParagraphs(1)}</p>
+  </>
+  <${Example}>
+    <strong>${lorem.generateParagraphs(1)}</strong>
+  </>
 `;

--- a/stories/_utils/Callout.js
+++ b/stories/_utils/Callout.js
@@ -1,0 +1,9 @@
+import { html } from 'htm/preact';
+
+export default function Callout({ children }) {
+  return html`
+    <div class="bg-neutral-300 p-4 my-2">
+      ${children}
+    </div>
+  `;
+}

--- a/stories/_utils/Callout.js
+++ b/stories/_utils/Callout.js
@@ -1,9 +1,0 @@
-import { html } from 'htm/preact';
-
-export default function Callout({ children }) {
-  return html`
-    <div class="bg-neutral-300 p-4 my-2">
-      ${children}
-    </div>
-  `;
-}

--- a/stories/_utils/Example.js
+++ b/stories/_utils/Example.js
@@ -1,0 +1,29 @@
+import { html } from 'htm/preact';
+import render from 'preact-render-to-string';
+import Prism from 'prismjs';
+
+function highlightWithPrism(code) {
+  return Prism.highlight(code, Prism.languages.html);
+}
+
+function renderString(input) {
+  return html([input]);
+}
+
+export default function Example({ className, children, ...rest }) {
+  const code = render(children);
+  const highlightedCode = highlightWithPrism(code);
+
+  return html`
+    <div class="border border-neutral-300 rounded ${className}" ...${rest}>
+      <div class="border-b border-neutral-300 p-4">
+        ${children}
+      </div>
+      <pre class="p-4 bg-neutral-200">
+        <code class="block max-w-full whitespace-pre-wrap leading-xs">
+          ${renderString(highlightedCode)}
+        </code>
+      </pre>
+    </div>
+  `;
+}

--- a/stories/_utils/InlineCode.js
+++ b/stories/_utils/InlineCode.js
@@ -1,0 +1,9 @@
+import { html } from 'htm/preact';
+
+export default function InlineCode({ children }) {
+  return html`
+    <code class="bg-neutral-200 rounded py-px px-1 border border-neutral-300 leading-none">
+      ${children}
+    </code>
+  `;
+}

--- a/stories/_utils/callout.js
+++ b/stories/_utils/callout.js
@@ -1,7 +1,0 @@
-export default function makeCallout(text) {
-  return `
-    <div style="padding: 16px; margin-top: 8px; margin-bottom: 8px;" class="bg-neutral-300">
-      ${text}
-    </div>
-  `;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5696,6 +5696,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
+htm@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.0.3.tgz#376163975363b3101dc9154046b1200f87790fcc"
+  integrity sha512-+LZu7FSZJNo/mGhF5zOgyLdcYTQ8brOqwJFXwP/F/Q9IyvBp3HcYT1tk5A6rf67NEW0VEV+2Y8O4pMGmBIci/w==
+
 html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
@@ -8300,6 +8305,18 @@ postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact-render-to-string@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.4.tgz#f26171f58f0e93b36236e4b0bee62ce561120b7c"
+  integrity sha512-fQyrkbn4Ustz5Gr4nQuTu2TIS+8IHqkIXf/SqstA2amgqLoPI6Z1e6Ttk5OL4jcE3MC6V+eaeRAed39sn8Oh4w==
+  dependencies:
+    pretty-format "^3.8.0"
+
+preact@^10.3.2:
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.2.tgz#1dabd1747b54de4e6820c7d2eadbb8bc4c2e3047"
+  integrity sha512-yIx4i7gp45enhzX4SLkvvR20UZ+YOUbMdj2KEscU/dC70MHv/L6dpTcsP+4sXrU9SRbA3GjJQQCPfFa5sE17dQ==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -8329,6 +8346,11 @@ pretty-error@^2.1.1:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8364,7 +8364,7 @@ pretty-ms@^5.1.0:
   dependencies:
     parse-ms "^2.1.0"
 
-prismjs@^1.8.4:
+prismjs@^1.19.0, prismjs@^1.8.4:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.19.0.tgz#713afbd45c3baca4b321569f2df39e17e729d4dc"
   integrity sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==


### PR DESCRIPTION
A big part of this PR is hooking up HTM and Preact, so that we can have things like components that we use to share functionality across our documentation pages. I thought about just using the React storybook support, but at least for now decided that that is quite a bit more heavy-handed than what we really need. I may decide to switch to that in the future, but for now Preact and HTM get us a similar experience with much less code.

The motivator to being in a component framework was to allow us to have a component that, given a snippet of code, would both render it _and_ show the code that produces it. This I was able to achieve pretty easily with the Preact libraries that are available. An example of what this looks like is here:

<img width="1000" alt="Screen Shot 2020-02-20 at 4 49 00 PM" src="https://user-images.githubusercontent.com/1645881/74984937-82d7bb00-5404-11ea-8e1f-f5cc9dcd1729.png">

I also went ahead and added a page about our color aliases, alongside our color palette example

<img width="993" alt="Screen Shot 2020-02-20 at 5 15 23 PM" src="https://user-images.githubusercontent.com/1645881/74984981-96832180-5404-11ea-8ea2-216a440d3cfa.png">

A bit of work was done to make our examples render more nicely if we ever embed them inside Notion. Now the background will appear white, rather than the weird gray-ish color that Notion injected into the page previously.