### PR TITLE
docs: fix indentation in code examples

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Percy Test
         uses: percy/storybook-action@v0.1.1
         with:
-          storybook-flags: '-s dist'
+          storybook-flags: '-s dist,node_modules/prismjs/themes'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "prismjs": "^1.19.0",
     "seedrandom": "^3.0.5",
     "standard-version": "^7.0.1",
-    "tailwindcss": "^1.1.4"
+    "tailwindcss": "^1.1.4",
+    "uuid": "^3.4.0"
   },
   "engines": {
     "node": ">=10.18"

--- a/stories/Utilities/Font/line-height.stories.js
+++ b/stories/Utilities/Font/line-height.stories.js
@@ -9,7 +9,7 @@ function makeLineHeightStory(size, notes) {
   return html`
     <p class="mb-4">${notes}</p>
     <${Example}>
-      <p class="leading-${size}">${lorem.generateParagraphs(1)}</p>A
+      <p class="leading-${size}">${lorem.generateParagraphs(1)}</p>
     </>
   `;
 }

--- a/stories/_utils/Example.js
+++ b/stories/_utils/Example.js
@@ -1,28 +1,32 @@
 import { html } from 'htm/preact';
 import render from 'preact-render-to-string';
 import Prism from 'prismjs';
+import { v4 as uuid } from 'uuid';
 
 function highlightWithPrism(code) {
   return Prism.highlight(code, Prism.languages.html);
 }
 
-function renderString(input) {
-  return html([input]);
-}
-
 export default function Example({ className, children, ...rest }) {
-  const code = render(children);
+  const code = render(children, {}, { pretty: true });
   const highlightedCode = highlightWithPrism(code);
+  const id = uuid();
+
+  // Necessary to "hack" the highlighted code example into the DOM so that
+  // indentation is preserved in an attractive way. Preact either strips the
+  // whitespace out completely, or inserts too much whitespace around the
+  // highlighted elements from Prism
+  requestAnimationFrame(() => {
+    document.getElementById(id).innerHTML = highlightedCode;
+  });
 
   return html`
     <div class="border border-neutral-300 rounded ${className}" ...${rest}>
       <div class="border-b border-neutral-300 p-4">
         ${children}
       </div>
-      <pre class="p-4 bg-neutral-200">
-        <code class="block max-w-full whitespace-pre-wrap leading-xs">
-          ${renderString(highlightedCode)}
-        </code>
+      <pre class="p-4 bg-neutral-200" style="tab-size: 2">
+        <code class="block max-w-full whitespace-pre-wrap leading-xs" id=${id} />
       </pre>
     </div>
   `;

--- a/stories/_utils/Example.js
+++ b/stories/_utils/Example.js
@@ -26,7 +26,7 @@ export default function Example({ className, children, ...rest }) {
         ${children}
       </div>
       <pre class="p-4 bg-neutral-200" style="tab-size: 2">
-        <code class="block max-w-full whitespace-pre-wrap leading-xs" id=${id} />
+        <code class="block max-w-full leading-xs overflow-x-scroll" id=${id} />
       </pre>
     </div>
   `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10651,7 +10651,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
I tried to get this working yesterday, but decided to just land the changes I was making with out it. Today I was able to work out a _very_ hacky solution to the problem I was seeing.

Preact, when rendering some content to a string, strips out all the whitespace. That made all of our code examples render like this:

<img width="968" alt="Screen Shot 2020-02-21 at 10 27 47 AM" src="https://user-images.githubusercontent.com/1645881/75047568-f6c1a400-5494-11ea-9b9c-771665276275.png">

Everything is on a single line. Not a bit deal for these really simple examples, but it would be nice to allow for multiple lines in cases, like a form or table, where the code example is a lot larger.

I was able to work out how to get the indentation "just right" by rendering the example to a string _with_ whitespace, when injecting that content into the code example outside of the Preact rendering cycle, bypassing its whitespace logic.

<img width="961" alt="Screen Shot 2020-02-21 at 10 27 26 AM" src="https://user-images.githubusercontent.com/1645881/75047691-35575e80-5495-11ea-86de-01f5d8a242e6.png">

With whitespace preserved, it's easier to read the examples, especially when we get to documenting more complex patterns.