### PR TITLE
Updated color palette docs

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@babel/plugin-transform-modules-commonjs"
+  ]
+}

--- a/stories/Guides/color.stories.js
+++ b/stories/Guides/color.stories.js
@@ -9,13 +9,17 @@ export default {
   title: 'Guides|Color',
 };
 
-function Cell({ color, value, className = value && value > 400 ? 'text-white' : '' }) {
+function Cell({ color, value, hex, className = '' }) {
   const identifier = value ? `${color}-${value}` : color;
 
   return html`
-    <div class="flex items-center justify-center bg-${identifier} ${className}">
+    <div class="flex items-center justify-between p-2 bg-${identifier} ${className}">
       <code class="text-sm">
         ${identifier}
+      </code>
+
+      <code class="text-sm">
+        ${hex}
       </code>
     </div>
   `;
@@ -24,17 +28,36 @@ function Cell({ color, value, className = value && value > 400 ? 'text-white' : 
 export const Palette = () => html`
   <h1 class="heading-md mb-2">Color Palette</h1>
 
-  ${colors.map((color) => {
-    const values = Object.keys(colorConfig[color]).filter((value) => value !== 'default');
+  <div class="grid grid-cols-3 gap-4">
+    ${colors.map((color) => {
+      const colorValues = colorConfig[color];
+      const values = Object.keys(colorValues).filter((value) => value !== 'default');
+      const defaultValue = values.find((value) => colorValues[value] === colorValues['default']);
 
-    return html`
-      <div class="grid grid-cols-9 h-24 mb-4">
-        ${values.map((value) => {
-          return html` <${Cell} color=${color} value=${value} /> `;
-        })}
-      </div>
-    `;
-  })}
+      return html`
+        <div class="">
+          ${values.map((value) => {
+            let className = '';
+
+            if (value === defaultValue) {
+              className = 'py-4';
+            }
+
+            if (value >= defaultValue) {
+              className += ' text-white';
+            }
+
+            return html` <${Cell}
+              className=${className}
+              color=${color}
+              value=${value === defaultValue ? undefined : value}
+              hex=${colorValues[value]}
+            />`;
+          })}
+        </div>
+      `;
+    })}
+  </div>
 `;
 
 export const Aliases = () => html`

--- a/stories/Guides/color.stories.js
+++ b/stories/Guides/color.stories.js
@@ -1,6 +1,10 @@
 import { html } from 'htm/preact';
 import Code from '../_utils/InlineCode';
 
+const colorConfig = require('../../config/colors');
+
+const colors = Object.keys(colorConfig).filter((color) => color !== 'white' && color !== 'black');
+
 export default {
   title: 'Guides|Color',
 };
@@ -20,87 +24,17 @@ function Cell({ color, value, className = value && value > 400 ? 'text-white' : 
 export const Palette = () => html`
   <h1 class="heading-md mb-2">Color Palette</h1>
 
-  <div class="grid grid-cols-9 h-24 mb-4">
-    <${Cell} color="neutral" value="100" />
-    <${Cell} color="neutral" value="200" />
-    <${Cell} color="neutral" value="300" />
-    <${Cell} color="neutral" value="400" />
-    <${Cell} color="neutral" value="500" />
-    <${Cell} color="neutral" value="600" />
-    <${Cell} color="neutral" value="700" />
-    <${Cell} color="neutral" value="800" />
-    <${Cell} color="neutral" value="900" />
-  </div>
+  ${colors.map((color) => {
+    const values = Object.keys(colorConfig[color]).filter((value) => value !== 'default');
 
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="red" value="100" />
-    <${Cell} color="red" value="200" />
-    <${Cell} color="red" value="300" />
-    <${Cell} color="red" value="400" />
-    <${Cell} color="red" value="500" />
-    <${Cell} color="red" value="600" />
-    <${Cell} color="red" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="orange" value="100" />
-    <${Cell} color="orange" value="200" />
-    <${Cell} color="orange" value="300" />
-    <${Cell} color="orange" value="400" />
-    <${Cell} color="orange" value="500" />
-    <${Cell} color="orange" value="600" />
-    <${Cell} color="orange" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="yellow" value="100" />
-    <${Cell} color="yellow" value="200" />
-    <${Cell} color="yellow" value="300" />
-    <${Cell} color="yellow" value="400" />
-    <${Cell} color="yellow" value="500" />
-    <${Cell} color="yellow" value="600" />
-    <${Cell} color="yellow" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="green" value="100" />
-    <${Cell} color="green" value="200" />
-    <${Cell} color="green" value="300" />
-    <${Cell} color="green" value="400" />
-    <${Cell} color="green" value="500" />
-    <${Cell} color="green" value="600" />
-    <${Cell} color="green" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="aqua" value="100" />
-    <${Cell} color="aqua" value="200" />
-    <${Cell} color="aqua" value="300" />
-    <${Cell} color="aqua" value="400" />
-    <${Cell} color="aqua" value="500" />
-    <${Cell} color="aqua" value="600" />
-    <${Cell} color="aqua" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="blue" value="100" />
-    <${Cell} color="blue" value="200" />
-    <${Cell} color="blue" value="300" />
-    <${Cell} color="blue" value="400" />
-    <${Cell} color="blue" value="500" />
-    <${Cell} color="blue" value="600" />
-    <${Cell} color="blue" value="700" />
-  </div>
-
-  <div class="grid grid-cols-7 h-24 mb-4">
-    <${Cell} color="violet" value="100" />
-    <${Cell} color="violet" value="200" />
-    <${Cell} color="violet" value="300" />
-    <${Cell} color="violet" value="400" />
-    <${Cell} color="violet" value="500" />
-    <${Cell} color="violet" value="600" />
-    <${Cell} color="violet" value="700" />
-  </div>
+    return html`
+      <div class="grid grid-cols-9 h-24 mb-4">
+        ${values.map((value) => {
+          return html` <${Cell} color=${color} value=${value} /> `;
+        })}
+      </div>
+    `;
+  })}
 `;
 
 export const Aliases = () => html`

--- a/stories/Guides/color.stories.js
+++ b/stories/Guides/color.stories.js
@@ -1,29 +1,17 @@
 import { html } from 'htm/preact';
-import Code from '../_utils/InlineCode';
 
 const colorConfig = require('../../config/colors');
 
-const colors = Object.keys(colorConfig).filter((color) => color !== 'white' && color !== 'black');
+const colors = Object.keys(colorConfig).filter((color) => typeof colorConfig[color] === 'object');
+const aliases = Object.keys(colorConfig).filter((color) => typeof colorConfig[color] === 'string');
+
+function getGlobalAlaisForHex(hex) {
+  return aliases.find((alias) => colorConfig[alias] === hex);
+}
 
 export default {
   title: 'Guides|Color',
 };
-
-function Cell({ color, value, hex, className = '' }) {
-  const identifier = value ? `${color}-${value}` : color;
-
-  return html`
-    <div class="flex items-center justify-between p-2 bg-${identifier} ${className}">
-      <code class="text-sm">
-        ${identifier}
-      </code>
-
-      <code class="text-sm">
-        ${hex}
-      </code>
-    </div>
-  `;
-}
 
 export const Palette = () => html`
   <h1 class="heading-md mb-2">Color Palette</h1>
@@ -35,8 +23,11 @@ export const Palette = () => html`
       const defaultValue = values.find((value) => colorValues[value] === colorValues['default']);
 
       return html`
-        <div class="">
+        <div>
           ${values.map((value) => {
+            const hex = colorValues[value];
+            const identifier = `${color}-${value}`;
+            const alias = getGlobalAlaisForHex(hex) || (value === defaultValue ? color : undefined);
             let className = '';
 
             if (value === defaultValue) {
@@ -47,86 +38,20 @@ export const Palette = () => html`
               className += ' text-white';
             }
 
-            return html` <${Cell}
-              className=${className}
-              color=${color}
-              value=${value === defaultValue ? undefined : value}
-              hex=${colorValues[value]}
-            />`;
+            return html`
+              <div class="flex items-center justify-between p-2 bg-${identifier} ${className}">
+                <code class="text-sm">
+                  ${alias ? `${alias} (${identifier})` : identifier}
+                </code>
+
+                <code class="text-sm">
+                  ${hex}
+                </code>
+              </div>
+            `;
           })}
         </div>
       `;
     })}
-  </div>
-`;
-
-export const Aliases = () => html`
-  <h1 class="heading-md mb-2">Color Aliases</h1>
-
-  <p class="body-base mb-2">
-    Each of our core colors has a alias, or shortcut, that can be used to avoid needing to provide
-    the color's numerical value.
-  </p>
-
-  <p class="body-base mb-2">
-    Each color's alias corresponds to the "middle" step for the range of values. For most colors,
-    this matches the <${Code}>400</${Code}> value. For <${Code}>neutral</${Code}> however, it
-    matches the <${Code}>500</${Code}> value.
-  </p>
-
-  <p class="body-base mb-2">
-    Additionally, an alias for <${Code}>black</${Code}> and <${Code}>white</${Code}> are provided.
-  </p>
-
-  <div class="grid grid-cols-2 gap-4">
-    <div class="grid grid-cols-2 gap-px h-24 bg-neutral-300 border border-neutral-300">
-      <${Cell} color="neutral" value="100" />
-      <${Cell} color="white" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="neutral" value="500" className="text-black" />
-      <${Cell} color="neutral" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="red" value="400" />
-      <${Cell} color="red" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="orange" value="400" />
-      <${Cell} color="orange" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="yellow" value="400" />
-      <${Cell} color="yellow" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="green" value="400" />
-      <${Cell} color="green" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="aqua" value="400" />
-      <${Cell} color="aqua" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="blue" value="400" />
-      <${Cell} color="blue" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="violet" value="400" />
-      <${Cell} color="violet" />
-    </div>
-
-    <div class="grid grid-cols-2 gap-px h-24">
-      <${Cell} color="neutral" value="900" />
-      <${Cell} color="black" className="text-white" />
-    </div>
   </div>
 `;


### PR DESCRIPTION
Took a pass at updating out color palette docs based on what Shopify does for Polaris

https://polaris.shopify.com/design/colors#section-color-palette

Now you can see the hex values for each color, and we actually pull the palette data from the configuration itself. No need to maintain two copies -- if change the color configuration, the documentation will change automatically too!

<img width="1187" alt="Screen Shot 2020-05-21 at 2 50 37 PM" src="https://user-images.githubusercontent.com/1645881/82594869-bdbbcd00-9b72-11ea-8284-ba7672afe7d0.png">
