### PR TITLE
Remove wrapper from code snippet

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,5 @@
 import { addDecorator, addParameters } from '@storybook/html';
 import { withHTML } from '@whitespace/storybook-addon-html/html';
-import { html } from 'htm/preact';
 import render from 'preact-render-to-string';
 import prettierConfig from '@movable/prettier-config';
 
@@ -14,13 +13,10 @@ addDecorator((storyFn) => {
   let result = storyFn();
 
   if (typeof result === 'string') {
-    result = html([result]);
+    return result;
   }
 
-  const rendered = render(result);
-
-  // Avoid printing serialization code for `<`
-  return rendered.replace(/&amp;/g, '&');
+  return render(result);
 });
 
 addDecorator(withHTML({ prettier: prettierConfig }));

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,7 @@ addParameters({
   },
 });
 
+// Allow using the Preact `html` tag in stories
 addDecorator((storyFn) => {
   let result = storyFn();
 
@@ -19,8 +20,10 @@ addDecorator((storyFn) => {
   return render(result);
 });
 
+// Add HTML code snippet addon
 addDecorator(withHTML({ prettier: prettierConfig }));
 
+// Add a wrapper element for better presentation
 addDecorator(
   (storyFn) => `
     <div class="p-4 bg-white h-screen">

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,14 +10,6 @@ addParameters({
   },
 });
 
-addDecorator(
-  (storyFn) => html`
-    <div class="p-4 bg-white h-screen">
-      ${storyFn()}
-    </div>
-  `
-);
-
 addDecorator((storyFn) => {
   let result = storyFn();
 
@@ -32,3 +24,11 @@ addDecorator((storyFn) => {
 });
 
 addDecorator(withHTML({ prettier: prettierConfig }));
+
+addDecorator(
+  (storyFn) => `
+    <div class="p-4 bg-white h-screen">
+      ${storyFn()}
+    </div>
+  `
+);


### PR DESCRIPTION
This change makes a small improvement to the HTML snippet rendered in the Addon panel for each story.

We use a Storybook "decorator" to wrap each story in a little spacing to avoid the elements from butting right up to the edges of the page.

However, the original way this was implemented, the wrapper element ended up in the snippet

<img width="748" alt="Screen Shot 2020-05-27 at 9 13 21 PM" src="https://user-images.githubusercontent.com/1645881/83087939-7a74c900-a060-11ea-99f1-d825a1d27637.png">

By re-ordering the decorators, we can avoid this and remove the wrapper from the snippet

<img width="727" alt="Screen Shot 2020-05-27 at 9 17 34 PM" src="https://user-images.githubusercontent.com/1645881/83087969-895b7b80-a060-11ea-8d05-45b71e63edc2.png">
