### PR TITLE
feat: add `fluid-button-group` styles

### DIFF
--- a/plugins/components/buttons.js
+++ b/plugins/components/buttons.js
@@ -368,5 +368,19 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
         },
       },
     },
+
+    /** === Button Group === **/
+    '.fluid-button-group': {
+      '> .fluid-button:not(:first-child)': {
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+        borderLeftWidth: 0,
+      },
+
+      '> .fluid-button:not(:last-child)': {
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+      },
+    },
   });
 };

--- a/stories/Components/Buttons/CookBook.stories.js
+++ b/stories/Components/Buttons/CookBook.stories.js
@@ -10,3 +10,11 @@ export const Anchor = () => html`
     <a class="fluid-button appearance:disabled">I am a (disabled) link</a>
   </div>
 `;
+
+export const ButtonGroup = () => html`
+  <div class="fluid-button-group">
+    <button class="fluid-button">Left Button</button>
+    <button class="fluid-button">Middle Button</button>
+    <button class="fluid-button">Right Button</button>
+  </div>
+`;


### PR DESCRIPTION
This adds a `.fluid-button-group` class that you can wrap around a set of buttons to place them into a "group".

Buttons in a group have their border radii set such that only the left-most and right-most buttons have rounded corners and there is only a single pixel of border between each of the buttons.

<img width="338" alt="Screen Shot 2020-06-03 at 10 55 46 AM" src="https://user-images.githubusercontent.com/1645881/83653753-2c912100-a58a-11ea-8c28-86b0a764f284.png">

🏠 [ch38600](https://app.clubhouse.io/movableink/story/38600)