### PR TITLE
Allow overriding button text color

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,8 @@
 module.exports = {
-  addons: ['@storybook/addon-a11y/register', '@whitespace/storybook-addon-html/register'],
+  addons: [
+    '@storybook/addon-a11y/register',
+    '@storybook/addon-backgrounds/register',
+    '@whitespace/storybook-addon-html/register',
+  ],
   stories: ['../stories/**/*.stories.[tj]s'],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,10 @@ addParameters({
   a11y: {
     element: '#fluid-root',
   },
+  backgrounds: [
+    { name: 'light', value: 'white', default: true },
+    { name: 'dark', value: 'black' },
+  ],
   options: {
     showRoots: true,
   },
@@ -33,7 +37,7 @@ addDecorator(withHTML({ prettier: prettierConfig }));
 // Add a wrapper element for better presentation
 addDecorator(
   (storyFn) => `
-    <div class="p-4 bg-white h-screen" id="fluid-root">
+    <div class="p-4 h-screen" id="fluid-root">
       ${storyFn()}
     </div>
   `

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@movable/prettier-config": "^0.3.0",
     "@percy/storybook": "^3.2.0",
     "@storybook/addon-a11y": "^5.3.19",
+    "@storybook/addon-backgrounds": "^5.3.19",
     "@storybook/html": "^5.3.9",
     "@whitespace/storybook-addon-html": "^1.2.1",
     "ava": "^3.1.0",

--- a/plugins/components/buttons.js
+++ b/plugins/components/buttons.js
@@ -78,6 +78,9 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
   addComponents({
     // Styles that belong to all buttons
     '.fluid-button': {
+      // Properties Customized by "Types"
+      color: 'var(--fluid-button-color)',
+
       // Display items inside button
       alignItems: 'center',
       display: 'inline-flex',
@@ -96,11 +99,20 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       whiteSpace: 'nowrap',
 
       ...disabled({
+        color: 'var(--fluid-button-color-disabled, var(--fluid-button-color))',
         cursor: 'not-allowed',
+      }),
+
+      ...hovered({
+        color: 'var(--fluid-button-color-hovered, var(--fluid-button-color))',
       }),
 
       ...focused({
         outline: 'none',
+      }),
+
+      ...active({
+        color: 'var(--fluid-button-color-active, var(--fluid-button-color))',
       }),
 
       svg: {
@@ -110,13 +122,13 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
 
     /** === Basic Button (Type) === **/
     [fluidButtonWithoutModifier('type')]: {
+      '--fluid-button-color': theme('colors.neutral.800'),
+      '--fluid-button-color-disabled': theme('colors.neutral.500'),
       backgroundColor: theme('colors.neutral.200'),
-      color: theme('colors.neutral.800'),
       borderColor: theme('colors.neutral.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
-        color: theme('colors.neutral.500'),
         borderColor: theme('colors.neutral.400'),
         boxShadow: 'none',
       }),
@@ -139,14 +151,14 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
 
     /** === Primary Button === **/
     [`.fluid-button.${e('type:primary')}`]: {
+      '--fluid-button-color': theme('colors.white'),
+      '--fluid-button-color-disabled': theme('colors.blue.200'),
       backgroundColor: theme('colors.blue.400'),
-      color: theme('colors.white'),
       borderColor: theme('colors.blue.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
         backgroundColor: theme('colors.blue.100'),
-        color: theme('colors.blue.200'),
         borderColor: theme('colors.blue.200'),
         boxShadow: 'none',
       }),
@@ -169,12 +181,12 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
 
     /** === Outline Button === **/
     [`.fluid-button.${e('type:outline')}`]: {
+      '--fluid-button-color': theme('colors.neutral.800'),
+      '--fluid-button-color-disabled': theme('colors.neutral.500'),
       backgroundColor: 'transparent',
-      color: theme('colors.neutral.800'),
       borderColor: theme('colors.neutral.500'),
 
       ...disabled({
-        color: theme('colors.neutral.500'),
         backgroundColor: 'rgba(255, 255, 255, 0.3)',
         borderColor: theme('colors.neutral.400'),
         boxShadow: 'none',
@@ -197,14 +209,15 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
 
     /** === Destructive Button === **/
     [`.fluid-button.${e('type:destructive')}`]: {
+      '--fluid-button-color': theme('colors.white'),
+      '--fluid-button-color-disabled': theme('colors.red.200'),
+      '--fluid-button-color-hovered': theme('colors.white'),
       backgroundColor: theme('colors.red.400'),
-      color: theme('colors.white'),
       borderColor: theme('colors.red.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
         backgroundColor: theme('colors.red.100'),
-        color: theme('colors.red.200'),
         borderColor: theme('colors.red.200'),
         boxShadow: 'none',
       }),
@@ -212,7 +225,6 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       ...hovered({
         background:
           'linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, 0.1) 100%) rgb(252, 81, 66)',
-        color: theme('colors.white'),
         borderColor: theme('colors.red.500'),
       }),
 
@@ -229,17 +241,12 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
 
     /** === Plain Button === **/
     [`.fluid-button.${e('type:plain')}`]: {
+      '--fluid-button-color': theme('colors.blue.400'),
+      '--fluid-button-color-disabled': theme('colors.neutral.500'),
+      '--fluid-button-color-hovered': theme('colors.blue.500'),
+      '--fluid-button-color-active': theme('colors.blue.300'),
       backgroundColor: 'transparent',
-      color: theme('colors.blue.400'),
       borderColor: 'transparent',
-
-      ...disabled({
-        color: theme('colors.neutral.500'),
-      }),
-
-      ...hovered({
-        color: theme('colors.blue.500'),
-      }),
 
       ...focused({
         boxShadow: FOCUSED_BOX_SHADOW,
@@ -249,7 +256,6 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       ...active({
         boxShadow: FOCUSED_BOX_SHADOW,
         borderColor: theme('colors.blue.300'),
-        color: theme('colors.blue.300'),
       }),
     },
 

--- a/stories/Components/Buttons/CookBook.stories.js
+++ b/stories/Components/Buttons/CookBook.stories.js
@@ -18,3 +18,12 @@ export const ButtonGroup = () => html`
     <button class="fluid-button">Right Button</button>
   </div>
 `;
+
+export const DarkMode = () => html`
+  <button class="fluid-button type:outline text-white">Click Me</button>
+`;
+DarkMode.story = {
+  parameters: {
+    backgrounds: [{ name: 'dark', value: 'black', default: true }],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,6 +1237,22 @@
     ts-dedent "^1.1.0"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-backgrounds@^5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-5.3.19.tgz#4efd995c8849498dba9a52b7a9085a6cdd2b28b4"
+  integrity sha512-1olfUaJL/VjlS86/WGJJVkhDVeFC9eONqa5G+yjCKgZS8BGN7G5em8GLo49ZO/F6VyWEB00K0dkAQbKEOa4jpQ==
+  dependencies:
+    "@storybook/addons" "5.3.19"
+    "@storybook/api" "5.3.19"
+    "@storybook/client-logger" "5.3.19"
+    "@storybook/components" "5.3.19"
+    "@storybook/core-events" "5.3.19"
+    "@storybook/theming" "5.3.19"
+    core-js "^3.0.1"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    util-deprecate "^1.0.2"
+
 "@storybook/addons@5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.19.tgz#3a7010697afd6df9a41b8c8a7351d9a06ff490a4"


### PR DESCRIPTION
This change allows the Tailwind `text-xxx` helpers to override the text color for a button.

## Current Behavior

The styles were written in such a way that the CSS, in a simplified way, looked something like this:

```css
.fluid-button.type:outline {
  color: 'black';
}

.text-white {
  color: 'white';
}
```

*Note: our buttons are specifically inserted into the CSS payload before the utilities, so we know that this order is the case*

We can imagine that some element wants to override the text color of the `type:outline` button to, for example, allow it to appear OK in a "dark mode" situation. It would provide the markup like this:

```html
<button class="fluid-button type:outline text-white">
  Click Me!
</button>
```

However, this doesn't work!

Because the `color` property is set at the conjunction of _two_ classes, the specificity of the selector that sets that property is 2. Because the specificity of `text-white` is only 1, the utility is unable to actually do anything useful here.

<img width="104" alt="Screen Shot 2020-06-04 at 4 09 09 PM" src="https://user-images.githubusercontent.com/1645881/83805374-c4236c00-a67d-11ea-90f8-dd11e3d16562.png">


## New Behavior

We need a way to ensure that `fluid-button` sets the color with a selector that has a specificity of only 1. If we can do that , then the relative order of the two classes will determine which style is actually applied. Since the utility is defined second, that color will "win" the way we want it do!

How can we set the `color` from a class with a specificity of 1? CSS variables!

Rather than having each `type:` define their own `color` property, we can instead have `fluid-button` set the color to a variable, and each `type:` define the variable. The specificity of the `color` setting from the button is still only 1, so the utility can essentially cause the button to just ignore the variable altogether.

```css
.fluid-button {
  color: var(--fluid-button-color);
}

.fluid-button.type:outline {
  --fluid-button-color: 'black';
}

.text-white {
  color: 'white';
}
```

Now, the HTML snippet above actually works!

<img width="113" alt="Screen Shot 2020-06-04 at 3 57 55 PM" src="https://user-images.githubusercontent.com/1645881/83805277-963e2780-a67d-11ea-9c2e-bd84b4f4cac6.png">

***

Note: I do plan on expanding the `background-color` and `border-color` to be overridable in the same way. We don't have a use-case for this yet, so I am going to hold off of that work for now, but ideally we should allow those colors to be tweaked by a Tailwind utility as well.

## To-Do

- [x] Migrate button states that set `color` to make use of CSS variables as well.