### PR TITLE
fix: allow Tailwind variants to override button styles

### DIFF
--- a/plugins/components/buttons.js
+++ b/plugins/components/buttons.js
@@ -99,20 +99,11 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       whiteSpace: 'nowrap',
 
       ...disabled({
-        color: 'var(--fluid-button-color-disabled, var(--fluid-button-color))',
         cursor: 'not-allowed',
-      }),
-
-      ...hovered({
-        color: 'var(--fluid-button-color-hovered, var(--fluid-button-color))',
       }),
 
       ...focused({
         outline: 'none',
-      }),
-
-      ...active({
-        color: 'var(--fluid-button-color-active, var(--fluid-button-color))',
       }),
 
       svg: {
@@ -123,12 +114,12 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     /** === Basic Button (Type) === **/
     [fluidButtonWithoutModifier('type')]: {
       '--fluid-button-color': theme('colors.neutral.800'),
-      '--fluid-button-color-disabled': theme('colors.neutral.500'),
       backgroundColor: theme('colors.neutral.200'),
       borderColor: theme('colors.neutral.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
+        '--fluid-button-color': theme('colors.neutral.500'),
         borderColor: theme('colors.neutral.400'),
         boxShadow: 'none',
       }),
@@ -152,12 +143,12 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     /** === Primary Button === **/
     [`.fluid-button.${e('type:primary')}`]: {
       '--fluid-button-color': theme('colors.white'),
-      '--fluid-button-color-disabled': theme('colors.blue.200'),
       backgroundColor: theme('colors.blue.400'),
       borderColor: theme('colors.blue.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
+        '--fluid-button-color': theme('colors.blue.200'),
         backgroundColor: theme('colors.blue.100'),
         borderColor: theme('colors.blue.200'),
         boxShadow: 'none',
@@ -182,11 +173,11 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     /** === Outline Button === **/
     [`.fluid-button.${e('type:outline')}`]: {
       '--fluid-button-color': theme('colors.neutral.800'),
-      '--fluid-button-color-disabled': theme('colors.neutral.500'),
       backgroundColor: 'transparent',
       borderColor: theme('colors.neutral.500'),
 
       ...disabled({
+        '--fluid-button-color': theme('colors.neutral.500'),
         backgroundColor: 'rgba(255, 255, 255, 0.3)',
         borderColor: theme('colors.neutral.400'),
         boxShadow: 'none',
@@ -210,19 +201,19 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     /** === Destructive Button === **/
     [`.fluid-button.${e('type:destructive')}`]: {
       '--fluid-button-color': theme('colors.white'),
-      '--fluid-button-color-disabled': theme('colors.red.200'),
-      '--fluid-button-color-hovered': theme('colors.white'),
       backgroundColor: theme('colors.red.400'),
       borderColor: theme('colors.red.500'),
       boxShadow: ELEVATED_BOX_SHADOW,
 
       ...disabled({
+        '--fluid-button-color': theme('colors.red.200'),
         backgroundColor: theme('colors.red.100'),
         borderColor: theme('colors.red.200'),
         boxShadow: 'none',
       }),
 
       ...hovered({
+        '--fluid-button-color': theme('colors.white'),
         background:
           'linear-gradient(-180deg, rgba(255, 255, 255, 0) 0%, rgba(0, 0, 0, 0.1) 100%) rgb(252, 81, 66)',
         borderColor: theme('colors.red.500'),
@@ -242,11 +233,16 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     /** === Plain Button === **/
     [`.fluid-button.${e('type:plain')}`]: {
       '--fluid-button-color': theme('colors.blue.400'),
-      '--fluid-button-color-disabled': theme('colors.neutral.500'),
-      '--fluid-button-color-hovered': theme('colors.blue.500'),
-      '--fluid-button-color-active': theme('colors.blue.300'),
       backgroundColor: 'transparent',
       borderColor: 'transparent',
+
+      ...disabled({
+        '--fluid-button-color': theme('colors.neutral.500'),
+      }),
+
+      ...hovered({
+        '--fluid-button-color': theme('colors.blue.500'),
+      }),
 
       ...focused({
         boxShadow: FOCUSED_BOX_SHADOW,
@@ -254,6 +250,7 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       }),
 
       ...active({
+        '--fluid-button-color': theme('colors.blue.300'),
         boxShadow: FOCUSED_BOX_SHADOW,
         borderColor: theme('colors.blue.300'),
       }),

--- a/stories/Components/Buttons/CookBook.stories.js
+++ b/stories/Components/Buttons/CookBook.stories.js
@@ -27,3 +27,9 @@ DarkMode.story = {
     backgrounds: [{ name: 'dark', value: 'black', default: true }],
   },
 };
+
+export const ColorOverride = () => html`
+  <button class="fluid-button type:plain text-green-400 hover:text-green-500">
+    Click Me
+  </button>
+`;


### PR DESCRIPTION
While #141 worked for the general case of override the default text color, it _did not_ work for overriding variants (like `hover:`).

Essentially, the selectors used to generate the styles for the different button states were higher specificity than the variant utilities provided by Tailwind. Our selectors are higher specificity because we write some explicit selector logic in them to ensure that, for example, the `hover` styles are not applied when a button is `disabled`.

The solution was to ensure that _only_ the actual `.fluid-button` selector ever sets the `color` property; all other selectors just set a CSS variable that that property reads from.

This has the benefit of simplifying the implementation, as we only have a single `--fluid-button-color` variable now.

An alternative implementation would be to define the top-level `color` property with a set of fallback variables that would allow us to dictate which variables take precedence over others. For example, we could do something like

```
color: var(--fluid-button-color-disabled, var(--fluid-button-color-hover, var(--fluid-button-color)))
```

to ensure that, if disabled, the hover styling is not applied. However, the actual set of variables is about 5 levels deep, and this seems like a more complex implementation that we need right now. This should also solve our problem while being less complex.