### PR TITLE
feat: add Fluid Input component

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const bodyTextComponentsPlugin = require('./plugins/components/body-text');
 const captionTextComponentsPlugin = require('./plugins/components/caption-text');
 const headingTextComponentsPlugin = require('./plugins/components/heading-text');
 const buttonComponentsPlugin = require('./plugins/components/buttons');
+const inputComponentsPlugin = require('./plugins/components/inputs');
 
 /**
  * Configures Tailwind to use Fluid's design tokens
@@ -37,5 +38,6 @@ module.exports = {
     captionTextComponentsPlugin,
     headingTextComponentsPlugin,
     buttonComponentsPlugin,
+    inputComponentsPlugin,
   ],
 };

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -17,7 +17,7 @@ module.exports = function fluidTailwindPlugin({ addBase, theme }) {
 
     'input, textarea': {
       '&::placeholder': {
-        color: theme('colors.neutral.500'),
+        color: theme('colors.neutral.600'),
       },
     },
   });

--- a/plugins/components/-utils.js
+++ b/plugins/components/-utils.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * @typedef {(input: string) => string} EscapeFunction
+ */
+
+/**
+ * This function returns a selector that matches elements with the
+ * given class if and only if the element _does not_ have a class that
+ * starts with the provided `modifier`.
+ *
+ * We use an attribute selector here to look into the `class` attribute
+ * for the presence of the modifier
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
+ *
+ * We combine this with the `:not` pseudo-class to reverse the selector
+ * and apply the styles when we do _not_ have that modifier somewhere in the
+ * class attribute
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/:not
+ *
+ * All of this allows the defintion of the given class to contain shared
+ * styles for all buttons without any of the Basic-specific styles, which
+ * the other class might then need to override.
+ *
+ * @param {EscapeFunction} e the escape function from Tailwind
+ * @param {string} className the class name to extend
+ * @param {string} modifier the "modifier" to avoid matching against in the selector
+ * @returns {string} the extended selector
+ */
+function classWithoutModifier(e, className, modifier) {
+  const escapedModifier = e(`${modifier}:`);
+
+  return `.${className}:not([class*="${escapedModifier}"])`;
+}
+
+module.exports = {
+  classWithoutModifier,
+};

--- a/plugins/components/-utils.js
+++ b/plugins/components/-utils.js
@@ -5,6 +5,17 @@
  */
 
 /**
+ * Create a Tailwind `@apply` usage from a list of classes
+ *
+ * @param {...string} classList
+ */
+function apply(...classList) {
+  return {
+    [`@apply ${classList.join(' ')}`]: {},
+  };
+}
+
+/**
  * This function returns a selector that matches elements with the
  * given class if and only if the element _does not_ have a class that
  * starts with the provided `modifier`.
@@ -36,5 +47,6 @@ function classWithoutModifier(e, className, modifier) {
 }
 
 module.exports = {
+  apply,
   classWithoutModifier,
 };

--- a/plugins/components/buttons.js
+++ b/plugins/components/buttons.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { classWithoutModifier } = require('./-utils');
+
 /**
  * Builds out the Fluid Button component classes
  *
@@ -49,31 +51,7 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
     };
   }
 
-  /**
-   * This function returns a selector that matches elements with the
-   * `.fluid-button` class if and only if the element _does not_ have a
-   * class that starts with the provided `modifier`.
-   *
-   * We use an attribute selector here to look into the `class` attribute
-   * for the presence of the modifier
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
-   *
-   * We combine this with the `:not` pseudo-class to reverse the selector
-   * and apply the styles when we do _not_ have that modifier somewhere in the
-   * class attribute
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/CSS/:not
-   *
-   * All of this allows the defintion of `.fluid-button` to contain shared
-   * styles for all buttons without any of the Basic-specific styles, which
-   * the other types of buttons might need to override.
-   */
-  function fluidButtonWithoutModifier(modifier) {
-    const escapedModifier = e(`${modifier}:`);
-
-    return `.fluid-button:not([class*="${escapedModifier}"])`;
-  }
+  const fluidButtonWithoutModifier = classWithoutModifier.bind(null, e, 'fluid-button');
 
   addComponents({
     // Styles that belong to all buttons

--- a/plugins/components/inputs.js
+++ b/plugins/components/inputs.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const { apply, classWithoutModifier } = require('./-utils');
+
+/**
+ * Builds out the Fluid Input component classes
+ */
+module.exports = function inputComponentsPlugin({ addComponents, e, theme }) {
+  const disabledAppearance = e(`appearance:disabled`);
+  const focusedAppearance = e(`appearance:focused`);
+  const invalidAppearance = e(`appearance:invalid`);
+  const warningAppearance = e(`appearance:warning`);
+
+  function disabled(styles) {
+    return {
+      [`&:disabled, &.${disabledAppearance}`]: {
+        ...styles,
+      },
+    };
+  }
+
+  function focused(styles) {
+    return {
+      [`&:focus, &.${focusedAppearance}`]: {
+        ...styles,
+      },
+    };
+  }
+
+  function invalid(styles) {
+    return {
+      [`&:invalid, &.${invalidAppearance}`]: {
+        ...styles,
+      },
+    };
+  }
+
+  function warning(styles) {
+    return {
+      [`&.${warningAppearance}`]: {
+        ...styles,
+      },
+    };
+  }
+
+  const fluidInputWithoutModifier = classWithoutModifier.bind(null, e, 'fluid-input');
+
+  addComponents({
+    '.fluid-input': {
+      ...apply(
+        // Typography
+        'font-sans',
+
+        // Border
+        'border',
+        'border-neutral-400',
+        'rounded',
+
+        // Required for positioning `::after` elements for icons
+        'relative'
+      ),
+
+      '--fluid-input-focus-shadow-color': theme('colors.blue.200'),
+
+      '&::placeholder': {
+        ...apply('text-neutral-600'),
+      },
+
+      ...focused({
+        ...apply('border-blue-300', 'outline-none'),
+
+        boxShadow: '0 0 0 2px var(--fluid-input-focus-shadow-color)',
+      }),
+
+      ...warning({
+        ...apply('text-orange-600', 'border-yellow-400'),
+
+        '--fluid-input-focus-shadow-color': theme('colors.yellow.200'),
+      }),
+
+      ...invalid({
+        ...apply('text-red-600', 'border-red-400'),
+
+        '--fluid-input-focus-shadow-color': theme('colors.red.200'),
+      }),
+
+      ...disabled({
+        ...apply('text-neutral-600', 'bg-neutral-300', 'border-neutral-500'),
+      }),
+    },
+
+    /** === Base Input Size === **/
+    [fluidInputWithoutModifier('size')]: {
+      ...apply('text-lg', 'p-2'),
+
+      // Need exact line-height
+      lineHeight: '24px',
+    },
+
+    /** === "Small" Input Size === **/
+    [`.fluid-input.${e('size:sm')}`]: {
+      ...apply('text-sm', 'py-1', 'px-2'),
+
+      // Need exact line-height
+      lineHeight: '20px',
+    },
+  });
+};

--- a/stories/Components/Inputs/Inputs.stories.js
+++ b/stories/Components/Inputs/Inputs.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default {
+  title: 'Components/Inputs',
+};
+
+export const Basic = () => (
+  <input className="fluid-input" aria-label="A Text Input Field" placeholder="Fill Me In!" />
+);
+
+export const WithButtonPairings = () => (
+  <div className="flex flex-col space-y-2">
+    <div className="flex items-center space-x-2">
+      <input
+        className="fluid-input size:sm col-span-2"
+        aria-label="A Small Input"
+        placeholder="Fill Me In!"
+      />
+      <button className="fluid-button">Click Me</button>
+    </div>
+
+    <div className="flex items-center space-x-2">
+      <input
+        className="fluid-input col-span-2"
+        aria-label="A Normal Input"
+        placeholder="Fill Me In!"
+      />
+      <button className="fluid-button size:lg">Click Me</button>
+    </div>
+  </div>
+);

--- a/stories/Components/Inputs/Sizes.stories.js
+++ b/stories/Components/Inputs/Sizes.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default {
+  title: 'Components/Inputs/Sizes',
+};
+
+export const Default = () => (
+  <input className="fluid-input" aria-label="A Normal Input" placeholder="Fill Me In!" />
+);
+
+export const Small = () => (
+  <input className="fluid-input size:sm" aria-label="A Small Input" placeholder="Fill Me In!" />
+);

--- a/stories/Components/Inputs/States.stories.js
+++ b/stories/Components/Inputs/States.stories.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default {
+  title: 'Components/Inputs/States',
+};
+
+export const Disabled = () => (
+  <input
+    aria-label="A Disabled Input"
+    className="fluid-input"
+    disabled
+    placeholder="A Disabled Input"
+  />
+);
+
+export const Invalid = () => (
+  <input
+    aria-label="An Invalid Input"
+    className="fluid-input appearance:invalid"
+    placeholder="An Input with Error"
+  />
+);
+
+export const Warning = () => (
+  <input
+    aria-label="An Input with Warning"
+    className="fluid-input appearance:warning"
+    placeholder="An Input with Warning"
+  />
+);


### PR DESCRIPTION
This PR introduces an Input style for Fluid based on the design work done by @loriahpope. 

## Usage Examples

The absolute most basic usage looks as follows:

```html
<input class="fluid-input" />
```

### Invalid State

The `.fluid-input` class responds to the native [`:invalid` psuedo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid) to enable the right styling for the presence of an error. While this is nice, it's unlikely to get much use, as it requires the use of the native form validation API. This is something that our Ember apps, at least, do (and will, most likely) not use.

This styling can also be used declaratively with an `appearance:invalid` class placed on the input. This is how our Ember apps will likely show an error state.

```html
<input class="fluid-input appearance:invalid" />
```

This was specifically designed to match the other classes that are available for declaratively using the visual style for a pseudo-selector that is otherwise applied by the CSS engine itself. We use this pattern for our buttons, such as `appearance:disabled`, which is required for a disabled button that actually uses a tag under-the-hood that is not specifically `<button>`.

Often, this might be rendered with an error message. An example of markup to achieve that might look as follows:

```html
<div class="flex flex-col space-y-2">
  <input class="fluid-input appearance:invalid" />
  <ul class="text-red-600">
    <li>This input is required</li>
  </ul>
</div>
```

There are some alternatives that could be considered to the above API:

* Should we rename `appearance:invalid` to something less verbose?

The current API decisions were made based on

1. Encourage the understanding of the CSS classes as a system
    Example: When I need to access an alternate state for an element, I need an `appearance:` class if I can't rely on the default behavior
2. Encourage the use of Tailwind utilities as much as possible
    Example: Rather than having a specific wrapper that _always_ goes around an input field, I can use the Tailwind utilities that are best suited for the job

One note is that examples for these types of use-cases will be made available through Storybook for developers to copy from when implementing their own work.

## Future Work

Rather than using the `.fluid-input` class directly, I plan to add a `<FluidInput />` class to our Ember components that will abstract over some of the common use-cases here:

* Showing an error message
* Rendering a label
* Rendering the optional additional label (for text like "required")

This way we can consolidate the common styling for an "input group" not as a CSS class, but through a higher-level Ember component.

## Trying This Out

Since I was not allowed to set up something like [Vercel](https://vercel.com) to automatically preview deployments of PRs with a working URL, you'll need to test out these changes locally.

```
git clone git@github.com:movableink/tailwind-config.git
git co fluid-input
git pull --force
yarn
yarn build
yarn start
```

This will start up Storybook locally, where you can play with the input styles on your own computer.

Percy is also a resource for viewing the new styles, as each Storybook story that was added has a corresponding Percy snapshot that can be viewed in the Percy "check" linked at the bottom of the PR.

## Open Questions

### Can we use the `.fluid-input` class?

Our existing Fluid Input styling also uses the same class name. This is partly a good thing, as we can upgrade those inputs easily. However, it ends up being a back thing insofar as there are other API changes that will need to be addressed in the existing inputs; error state, the right way to label them, etc.

`.fluid-input` goes quite nicely with `.fluid-button`, though, so I'm not sure if a different name altogether really makes sense.

Another option would be to use `.form-input` and match the Tailwind UI configuration

https://tailwindcss-custom-forms.netlify.app

## To-Do

- [x] Write up a real PR description
- [x] Squash all `feat` commits into one (for a better `CHANGELOG`; keeping separate for now to ease development and review)
