### PR TITLE
Add `border` variants, `shadow-outline` utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,25 @@ module.exports = {
     letterSpacing,
     lineHeight,
     screens: {},
+
+    // External Plugin Config
+    shadowOutline: {
+      shadow: '0 0 0 2px',
+      alpha: '1',
+    },
+    shadowOutlineColors: {
+      blue: {
+        200: colors.blue['200'],
+      },
+      red: {
+        200: colors.red['200'],
+      },
+      orange: {
+        200: colors.orange['200'],
+      },
+    },
+
+    // Add to initial palette
     extend: {
       fill: colors,
       stroke: colors,
@@ -43,6 +62,9 @@ module.exports = {
   },
   variants: {
     borderColor: BORDER_COLOR_VARIANTS,
+
+    // External Plugin Config
+    shadowOutline: ['focus', 'focus-within'],
   },
   plugins: [
     fluidBasePlugin,
@@ -50,6 +72,9 @@ module.exports = {
     captionTextComponentsPlugin,
     headingTextComponentsPlugin,
     buttonComponentsPlugin,
+
+    // External Plugins
+    require('tailwindcss-shadow-outline-colors')(),
   ],
 
   // Export constants used in configuration to enable extension

--- a/index.js
+++ b/index.js
@@ -14,6 +14,16 @@ const captionTextComponentsPlugin = require('./plugins/components/caption-text')
 const headingTextComponentsPlugin = require('./plugins/components/heading-text');
 const buttonComponentsPlugin = require('./plugins/components/buttons');
 
+const BORDER_COLOR_VARIANTS = [
+  // Default
+  'responsive',
+  'hover',
+  'focus',
+  // Custom
+  'disabled',
+  'focus-within',
+];
+
 /**
  * Configures Tailwind to use Fluid's design tokens
  */
@@ -31,6 +41,9 @@ module.exports = {
       stroke: colors,
     },
   },
+  variants: {
+    borderColor: BORDER_COLOR_VARIANTS,
+  },
   plugins: [
     fluidBasePlugin,
     bodyTextComponentsPlugin,
@@ -38,4 +51,7 @@ module.exports = {
     headingTextComponentsPlugin,
     buttonComponentsPlugin,
   ],
+
+  // Export constants used in configuration to enable extension
+  BORDER_COLOR_VARIANTS,
 };

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
   "volta": {
     "node": "12.17.0",
     "yarn": "1.22.4"
+  },
+  "dependencies": {
+    "tailwindcss-shadow-outline-colors": "^0.0.8"
   }
 }

--- a/stories/Utilities/Shadow.stories.js
+++ b/stories/Utilities/Shadow.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default {
+  title: 'Utilities/Shadow',
+};
+
+export const Outline = () => (
+  <div className="flex space-x-2">
+    <div className="bg-neutral-300 h-8 w-8 shadow-outline-blue-300"></div>
+    <div className="bg-neutral-300 h-8 w-8 shadow-outline-red-200"></div>
+    <div className="bg-neutral-300 h-8 w-8 shadow-outline-yellow-200"></div>
+  </div>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11409,6 +11409,14 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tailwindcss-shadow-outline-colors@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/tailwindcss-shadow-outline-colors/-/tailwindcss-shadow-outline-colors-0.0.8.tgz#0fa4a729636ad509eb51c96fa795578092459b67"
+  integrity sha512-HY+WeCmttEhZXPpFbzbVy90f3g3Oe2crCwwRV3wtvZx6GfVMh2x4ZAsF8r1clshq8hWKu18t2io5hQkhhMx1+w==
+  dependencies:
+    color "^3.1.2"
+    lodash "^4.17.15"
+
 tailwindcss@^1.1.4:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.8.5.tgz#3b4624530b5fd71688fd04d16d8bd8c8d56834de"


### PR DESCRIPTION
This adds a few changes to the Tailwind config that will be necessary to build out the Ember `FluidTextInput` component using Tailwind.