### PR TITLE
fix: add border between `type:plain` buttons in group

### DIFF
--- a/plugins/components/buttons.js
+++ b/plugins/components/buttons.js
@@ -379,12 +379,17 @@ module.exports = function buttonComponentsPlugin({ addComponents, e, theme }) {
       '> .fluid-button:not(:first-child)': {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,
-        borderLeftWidth: 0,
       },
 
       '> .fluid-button:not(:last-child)': {
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
+        borderRightWidth: 0,
+      },
+
+      // Add border between `type:plain` buttons
+      [`> .fluid-button.${e('type:plain')} ~ .fluid-button.${e('type:plain')}`]: {
+        borderLeftColor: theme('colors.neutral.500'),
       },
     },
   });

--- a/stories/Components/ButtonGroup.stories.js
+++ b/stories/Components/ButtonGroup.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default {
+  title: 'Components/Button Group',
+};
+
+export const Basic = () => (
+  <div className="fluid-button-group">
+    <button className="fluid-button">Left</button>
+    <button className="fluid-button">Center</button>
+    <button className="fluid-button">Right</button>
+  </div>
+);
+
+export const Plain = () => (
+  <div className="fluid-button-group">
+    <button className="fluid-button type:plain">Left</button>
+    <button className="fluid-button type:plain">Center</button>
+    <button className="fluid-button type:plain">Right</button>
+  </div>
+);


### PR DESCRIPTION
Currently, the `fluid-button-group` -- when applied to buttons of `type:plain` -- looks like this:

<img width="173" alt="Screen Shot 2020-09-24 at 5 05 50 PM" src="https://user-images.githubusercontent.com/1645881/94200433-69aa5780-fe88-11ea-9606-9b7af313284f.png">

However, throughout our platform where this pattern is used (not often, but it does happen) we introduce a dividing line between them.

Unfortunately, due to CSS specificity, we can't use the `divide` helper from Tailwind to make it work explicitly.

What would be better, though, is making it "just work" and having a nice dividing line between the buttons automatically, which this PR introduces.

<img width="181" alt="Screen Shot 2020-09-24 at 5 06 17 PM" src="https://user-images.githubusercontent.com/1645881/94200546-93fc1500-fe88-11ea-8894-3e3a20d499ac.png">

Closes #256 