### PR TITLE
Update GitHub Action for Percy

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -57,8 +57,8 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install
       - name: Percy Test
-        uses: percy/storybook-action@v0.1.1
+        uses: percy/storybook-action@v0.1.6
         with:
-          storybook-flags: '-s dist,node_modules/prismjs/themes'
+          storybook-flags: '-s dist'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,7 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: volta-cli/action@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
I noticed an issue with how Storybook is rendering in Percy when we make use of the Background addon, introduced in #305.

We're also out-of-date with our Percy action, so I am hoping that this (somehow) will fix that issue. It might not, but it's worth trying.

There's an issue with `npx` (used in the updated Percy action) and Volta (volta-cli/action#48) so we're manually defining the whole command to run,rather than running the default `npx`-based command.

