### PR TITLE
[Feat] Fluid Table Cell - Prototype!

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const bodyTextComponentsPlugin = require('./plugins/components/body-text');
 const captionTextComponentsPlugin = require('./plugins/components/caption-text');
 const headingTextComponentsPlugin = require('./plugins/components/heading-text');
 const buttonComponentsPlugin = require('./plugins/components/buttons');
+const tableCellComponentsPlugin = require('./plugins/components/table-cells');
 
 const BORDER_COLOR_VARIANTS = [
   // Default
@@ -69,6 +70,7 @@ module.exports = {
     captionTextComponentsPlugin,
     headingTextComponentsPlugin,
     buttonComponentsPlugin,
+    tableCellComponentsPlugin,
   ],
 
   // Export constants used in configuration to enable extension

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/tailwind-config",
-  "version": "2.2.0-alpha.1",
+  "version": "2.1.0",
   "description": "Tailwind Config for Fluid",
   "main": "index.js",
   "repository": "git@github.com:movableink/tailwind-config.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/tailwind-config",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha.1",
   "description": "Tailwind Config for Fluid",
   "main": "index.js",
   "repository": "git@github.com:movableink/tailwind-config.git",

--- a/plugins/components/table-cells.js
+++ b/plugins/components/table-cells.js
@@ -11,14 +11,6 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
     paddingRight: 'var(--fluid-table-cell-x-spacing)',
     paddingBottom: 'var(--fluid-table-cell-y-spacing)',
     paddingLeft: 'var(--fluid-table-cell-x-spacing)',
-
-    svg: {
-      height: theme('height.4'),
-      width: theme('width.4'),
-      display: 'inline-block',
-      marginLeft: theme('margin.3'),
-      marginRight: theme('margin.3'),
-    },
   };
 
   const tableCellClass = '.fluid-table__td';
@@ -29,6 +21,10 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
     [`${tableCellClass}`]: {
       ...defaultClasses,
     },
+    /** == No Spacing == **/
+    [`${tableCellClass}.${e('spacing:none')}`]: {},
+    [`${tableHeaderCellClass}.${e('spacing:none')}`]: {},
+
     [`${tableCellClass}:not([class*="spacing"])`]: {
       '--fluid-table-cell-x-spacing': theme('padding.3'),
       '--fluid-table-cell-y-spacing': theme('padding.3'),
@@ -48,7 +44,6 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
       '--fluid-table-cell-x-spacing': theme('padding.2'),
       '--fluid-table-cell-y-spacing': theme('padding.1'),
     },
-
     /** == Table Header Cell == **/
     [`${tableHeaderCellClass}`]: {
       ...defaultClasses,
@@ -56,6 +51,7 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
       backgroundColor: theme('colors.neutral.300'),
       textAlign: 'left',
     },
+    /** == No Spacing Modifier == **/
     [`${tableHeaderCellClass}:not([class*="spacing"])`]: {
       '--fluid-table-cell-x-spacing': theme('padding.3'),
       '--fluid-table-cell-y-spacing': theme('padding.3'),
@@ -74,6 +70,14 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
     [`${tableHeaderCellClass}.${e('spacing:compact')}`]: {
       '--fluid-table-cell-x-spacing': theme('padding.2'),
       '--fluid-table-cell-y-spacing': theme('padding.1'),
+    },
+    /** == ICON ==**/
+    '.fluid-table-cell-icon': {
+      height: theme('height.4'),
+      width: theme('width.4'),
+      display: 'inline-block',
+      marginLeft: theme('margin.3'),
+      marginRight: theme('margin.3'),
     },
   });
 };

--- a/plugins/components/table-cells.js
+++ b/plugins/components/table-cells.js
@@ -1,0 +1,70 @@
+'use strict';
+
+module.exports = function tableCellComponentsPlugin({ addComponents, e, theme }) {
+  const defaultClasses = {
+    borderBottomWidth: '1px',
+    borderColor: theme('colors.neutral.400'),
+    color: theme('colors.neutral.700'),
+    fontSize: theme('fontSize.base'),
+
+    paddingTop: 'var(--fluid-table-cell-spacing)',
+    paddingRight: 'var(--fluid-table-cell-spacing)',
+    paddingBottom: 'var(--fluid-table-cell-spacing)',
+    paddingLeft: 'var(--fluid-table-cell-spacing)',
+
+    svg: {
+      height: theme('height.4'),
+      width: theme('width.4'),
+      display: 'inline-block',
+      marginLeft: theme('margin.3'),
+      marginRight: theme('margin.3'),
+    },
+  };
+
+  const tableCellClass = '.fluid-table__td';
+  const tableHeaderCellClass = '.fluid-table__th';
+
+  addComponents({
+    /** == Table Cell == **/
+    [`${tableCellClass}`]: {
+      ...defaultClasses,
+    },
+    [`${tableCellClass}:not([class*="spacing"])`]: {
+      '--fluid-table-cell-spacing': theme('padding.3'),
+    },
+    /** == Default Spacing == **/
+    [`${tableCellClass}.${e('spacing:default')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.3'),
+    },
+    /** == Relaxed Spacing == **/
+    [`${tableCellClass}.${e('spacing:relaxed')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.4'),
+    },
+    /** == Compact Spacing == **/
+    [`${tableCellClass}.${e('spacing:compact')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.2'),
+    },
+
+    /** == Table Header Cell == **/
+    [`${tableHeaderCellClass}`]: {
+      ...defaultClasses,
+      fontStyle: theme('fontStyle.bold'),
+      backgroundColor: theme('colors.neutral.300'),
+    },
+    /** == Default Spacing == **/
+    [`${tableHeaderCellClass}:not([class*="spacing"])`]: {
+      '--fluid-table-cell-spacing': theme('padding.3'),
+    },
+    [`${tableHeaderCellClass}.${e('spacing:default')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.3'),
+    },
+    /** == Relaxed Spacing == **/
+    [`${tableHeaderCellClass}.${e('spacing:relaxed')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.4'),
+    },
+    /** == Compact Spacing == **/
+    [`${tableHeaderCellClass}.${e('spacing:compact')}`]: {
+      '--fluid-table-cell-spacing': theme('padding.2'),
+    },
+  });
+};

--- a/plugins/components/table-cells.js
+++ b/plugins/components/table-cells.js
@@ -7,10 +7,10 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
     color: theme('colors.neutral.700'),
     fontSize: theme('fontSize.base'),
 
-    paddingTop: 'var(--fluid-table-cell-spacing)',
-    paddingRight: 'var(--fluid-table-cell-spacing)',
-    paddingBottom: 'var(--fluid-table-cell-spacing)',
-    paddingLeft: 'var(--fluid-table-cell-spacing)',
+    paddingTop: 'var(--fluid-table-cell-y-spacing)',
+    paddingRight: 'var(--fluid-table-cell-x-spacing)',
+    paddingBottom: 'var(--fluid-table-cell-y-spacing)',
+    paddingLeft: 'var(--fluid-table-cell-x-spacing)',
 
     svg: {
       height: theme('height.4'),
@@ -30,19 +30,23 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
       ...defaultClasses,
     },
     [`${tableCellClass}:not([class*="spacing"])`]: {
-      '--fluid-table-cell-spacing': theme('padding.3'),
+      '--fluid-table-cell-x-spacing': theme('padding.3'),
+      '--fluid-table-cell-y-spacing': theme('padding.3'),
     },
     /** == Default Spacing == **/
     [`${tableCellClass}.${e('spacing:default')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.3'),
+      '--fluid-table-cell-x-spacing': theme('padding.3'),
+      '--fluid-table-cell-y-spacing': theme('padding.3'),
     },
     /** == Relaxed Spacing == **/
     [`${tableCellClass}.${e('spacing:relaxed')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.4'),
+      '--fluid-table-cell-x-spacing': theme('padding.4'),
+      '--fluid-table-cell-y-spacing': theme('padding.4'),
     },
     /** == Compact Spacing == **/
     [`${tableCellClass}.${e('spacing:compact')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.2'),
+      '--fluid-table-cell-x-spacing': theme('padding.2'),
+      '--fluid-table-cell-y-spacing': theme('padding.1'),
     },
 
     /** == Table Header Cell == **/
@@ -50,21 +54,26 @@ module.exports = function tableCellComponentsPlugin({ addComponents, e, theme })
       ...defaultClasses,
       fontStyle: theme('fontStyle.bold'),
       backgroundColor: theme('colors.neutral.300'),
+      textAlign: 'left',
+    },
+    [`${tableHeaderCellClass}:not([class*="spacing"])`]: {
+      '--fluid-table-cell-x-spacing': theme('padding.3'),
+      '--fluid-table-cell-y-spacing': theme('padding.3'),
     },
     /** == Default Spacing == **/
-    [`${tableHeaderCellClass}:not([class*="spacing"])`]: {
-      '--fluid-table-cell-spacing': theme('padding.3'),
-    },
     [`${tableHeaderCellClass}.${e('spacing:default')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.3'),
+      '--fluid-table-cell-x-spacing': theme('padding.3'),
+      '--fluid-table-cell-y-spacing': theme('padding.3'),
     },
     /** == Relaxed Spacing == **/
     [`${tableHeaderCellClass}.${e('spacing:relaxed')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.4'),
+      '--fluid-table-cell-x-spacing': theme('padding.4'),
+      '--fluid-table-cell-y-spacing': theme('padding.4'),
     },
     /** == Compact Spacing == **/
     [`${tableHeaderCellClass}.${e('spacing:compact')}`]: {
-      '--fluid-table-cell-spacing': theme('padding.2'),
+      '--fluid-table-cell-x-spacing': theme('padding.2'),
+      '--fluid-table-cell-y-spacing': theme('padding.1'),
     },
   });
 };

--- a/stories/Components/TableCells/NumberCells.stories.js
+++ b/stories/Components/TableCells/NumberCells.stories.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export default {
+  title: 'Components/Table Cells/Number Cells',
+};
+
+export const NumberCell = () => (
+  <div className="grid grid-cols-1 gap-2">
+    <p>
+      When using the table cell for number data the cell should always be right aligned, using the
+      class `text-right`
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th className="fluid-table__th">Data</th>
+          <th className="fluid-table__th text-right">Amount</th>
+          <th className="fluid-table__th text-right">Percent</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:compact">Compact Spacing</td>
+          <td className="fluid-table__td spacing:compact text-right">$1.00</td>
+          <td className="fluid-table__td spacing:compact text-right">90%</td>
+        </tr>
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:default">Default Spacing</td>
+          <td className="fluid-table__td spacing:default text-right">$1.00</td>
+          <td className="fluid-table__td spacing:default text-right">90%</td>
+        </tr>
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:relaxed">Relaxed Spacing</td>
+          <td className="fluid-table__td spacing:relaxed text-right">$1.00</td>
+          <td className="fluid-table__td spacing:relaxed text-right">90%</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+);

--- a/stories/Components/TableCells/TableCells.stories.js
+++ b/stories/Components/TableCells/TableCells.stories.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import Gear from '../../_icons/Gear';
+
+export default {
+  title: 'Components/Table Cells',
+};
+
+export const Spacing = () => (
+  <div className="grid grid-cols-1 gap-2">
+    <table>
+      <thead>
+        <tr>
+          <th className="fluid-table__th spacing:default">Text Only</th>
+          <th className="fluid-table__th spacing:default">
+            <Gear />
+            Icon Left w/Text
+          </th>
+          <th className="fluid-table__th spacing:default">
+            Icon Right w/Text
+            <Gear />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            className="fluid-table__th spacing:default bg-transparent text-neutral-500 italic"
+            colSpan="3"
+          >
+            No Spacing Modifier!
+          </th>
+        </tr>
+        <tr className="divide-x">
+          <td className="fluid-table__td">No Spacing</td>
+          <td className="fluid-table__td">
+            <Gear />
+            No Spacing
+          </td>
+          <td className="fluid-table__td">
+            No Spacing
+            <Gear />
+          </td>
+        </tr>
+        <tr>
+          <th
+            className="fluid-table__th spacing:default bg-transparent text-neutral-500 italic"
+            colSpan="3"
+          >
+            Modifier `spacing:default`
+          </th>
+        </tr>
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:default">Default Spacing</td>
+          <td className="fluid-table__td spacing:default">
+            <Gear />
+            Default Spacing
+          </td>
+          <td className="fluid-table__td spacing:default">
+            Default Spacing
+            <Gear />
+          </td>
+        </tr>
+
+        <tr>
+          <th
+            className="fluid-table__th spacing:relaxed bg-transparent text-neutral-500 italic"
+            colSpan="3"
+          >
+            Modifier `spacing:relaxed`
+          </th>
+        </tr>
+
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:relaxed">Relax Spacing</td>
+          <td className="fluid-table__td spacing:relaxed">
+            <Gear />
+            <span>Relax Spacing</span>
+          </td>
+          <td className="fluid-table__td spacing:relaxed">
+            <span>Relax Spacing</span>
+            <Gear />
+          </td>
+        </tr>
+
+        <tr>
+          <th
+            className="fluid-table__th spacing:relaxed bg-transparent text-neutral-500 italic"
+            colSpan="3"
+          >
+            Modifier `spacing:compact`
+          </th>
+        </tr>
+
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:compact">Compact Spacing</td>
+          <td className="fluid-table__td spacing:compact">
+            <Gear />
+            Compact Spacing
+          </td>
+          <td className="fluid-table__td spacing:compact">
+            Compact Spacing
+            <Gear />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+);

--- a/stories/Components/TableCells/TableCells.stories.js
+++ b/stories/Components/TableCells/TableCells.stories.js
@@ -12,12 +12,12 @@ export const Spacing = () => (
         <tr>
           <th className="fluid-table__th spacing:default">Text Only</th>
           <th className="fluid-table__th spacing:default">
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
             Icon Left w/Text
           </th>
           <th className="fluid-table__th spacing:default">
             Icon Right w/Text
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
           </th>
         </tr>
       </thead>
@@ -33,12 +33,12 @@ export const Spacing = () => (
         <tr className="divide-x">
           <td className="fluid-table__td">No Spacing</td>
           <td className="fluid-table__td">
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
             No Spacing
           </td>
           <td className="fluid-table__td">
             No Spacing
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
           </td>
         </tr>
         <tr>
@@ -52,12 +52,12 @@ export const Spacing = () => (
         <tr className="divide-x">
           <td className="fluid-table__td spacing:default">Default Spacing</td>
           <td className="fluid-table__td spacing:default">
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
             Default Spacing
           </td>
           <td className="fluid-table__td spacing:default">
             Default Spacing
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
           </td>
         </tr>
 
@@ -73,12 +73,12 @@ export const Spacing = () => (
         <tr className="divide-x">
           <td className="fluid-table__td spacing:relaxed">Relax Spacing</td>
           <td className="fluid-table__td spacing:relaxed">
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
             <span>Relax Spacing</span>
           </td>
           <td className="fluid-table__td spacing:relaxed">
             <span>Relax Spacing</span>
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
           </td>
         </tr>
 
@@ -94,12 +94,38 @@ export const Spacing = () => (
         <tr className="divide-x">
           <td className="fluid-table__td spacing:compact">Compact Spacing</td>
           <td className="fluid-table__td spacing:compact">
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
             Compact Spacing
           </td>
           <td className="fluid-table__td spacing:compact">
             Compact Spacing
-            <Gear />
+            <Gear className="fluid-table-cell-icon" />
+          </td>
+        </tr>
+
+        <tr>
+          <th
+            className="fluid-table__th spacing:relaxed bg-transparent text-neutral-500 italic"
+            colSpan="3"
+          >
+            Modifier `spacing:none`
+            <br />
+            <em className="font-normal">
+              This is an escape hatch to be used when you do <strong>NOT</strong> want spacing
+              included. *All other styles are included like borders, font stylings.
+            </em>
+          </th>
+        </tr>
+
+        <tr className="divide-x">
+          <td className="fluid-table__td spacing:none">No Spacing</td>
+          <td className="fluid-table__td spacing:none">
+            <Gear className="fluid-table-cell-icon" />
+            No Spacing
+          </td>
+          <td className="fluid-table__td spacing:none">
+            No Spacing
+            <Gear className="fluid-table-cell-icon" />
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
# Why
We want to refactor our `fluid-table__td` and `fluid-table_th` to be able to have an API just like our buttons.

### Before
Spacing relied on table down.
```hbs
<FluidTable isCompressed={{true}} as |table|>
  <tr>
    <table.td>Data Text</table.td>
 </tr>
</FluidTable>
```


### After
Spacing is driven from the cell. 
```hbs
<table>
  <tr>
    <td class="fluid-table__td spacing:compact">Data Text</td>
  </tr>
<table>
```

### Storybook
![Spacing](https://user-images.githubusercontent.com/1427852/123856357-fe962180-d8ee-11eb-8a37-cf0c5d10f767.png)

![Numbers](https://user-images.githubusercontent.com/1427852/123859307-7c0f6100-d8f2-11eb-8b1a-e7c9f19991cd.png)


# Details
I've added some class selectors so we can easily migrate to non-BEM syntax in the future. This was done to achieve **zero** refactors on the canvas side of things other than deleting css.

[🏠 [ch53928]](https://app.clubhouse.io/movableink/story/53928)