### PR TITLE
Update Development Environment Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,17 +10,17 @@ After cloning this repository and installing the dependencies by running
 yarn install
 ```
 
-You can build and run Storybook through the following:
+In one terminal window, run the following to build the Tailwind output and automatically re-build when any input files change:
 
 ```bash
-yarn build
-yarn start
+yarn build --watch
 ```
 
-- `yarn build` creates the Tailwind stylesheet
-- `yarn start` runs Storybook
+In another terminal window, run the following to start Storybook and create a development environment for the Tailwind config:
 
-If you change the Tailwind configuration, make sure to run `yarn build` again to re-build the CSS file.
+```bash
+yarn storybook
+```
 
 ## Conventional Commits
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "plugins"
   ],
   "scripts": {
-    "build": "tailwind build css/tailwind-imports.css --config index.js -o dist/fluid-tailwind.css",
+    "build": "tailwind build -i css/tailwind-imports.css --config index.js -o dist/fluid-tailwind.css",
     "compress": "csso dist/fluid-tailwind.css --output dist/fluid-tailwind.min.css --source-map file --no-restructure",
     "start": "start-storybook -s dist",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tailwind build -i css/tailwind-imports.css --config index.js -o dist/fluid-tailwind.css",
     "compress": "csso dist/fluid-tailwind.css --output dist/fluid-tailwind.min.css --source-map file --no-restructure",
-    "start": "start-storybook -s dist",
+    "storybook": "start-storybook -s dist",
     "lint": "eslint .",
     "pretest": "yarn build",
     "test": "ava",


### PR DESCRIPTION
After our (@nicksteffens and I's) conversation a few days ago on Slack, I realized that the development environment documentation left a lot to be desired.

Tailwind now (and maybe always, though I'm not sure) supports a `--watch` flag for re-building the output when any input (config or CSS base files) change, which is now documented. It has also been made clear that two terminal windows (or TMUX panes, or _something_) are needed to run both Storybook _and_ the Tailwind build at the same time.