### PR TITLE
fix(security): shell-quote has been flagged <1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "seedrandom": "^3.0.5",
     "tailwindcss": "^2.1.1"
   },
+  "resolutions": {
+    "shell-quote": "^1.7.3"
+  },
   "engines": {
     "node": ">=10.18"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15162,10 +15162,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.7.2":
-  version: 1.7.2
-  resolution: "shell-quote@npm:1.7.2"
-  checksum: efad426fb25d8a54d06363f1f45774aa9e195f62f14fa696d542b44bfe418ab41206448b63af18d726c62e099e66d9a3f4f44858b9ea2ce4b794b41b802672d1
+"shell-quote@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "shell-quote@npm:1.7.3"
+  checksum: aca58e73a3a5d933d02e0bdddedc53ee14f7c2ec264f97ac915b9d4482d077a38e422aa664631d60a672cd3cdb4054eb2e6c0303f54882453dacb6483e482d34
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- This can allow command injection

[🎟️[sc-66417]](https://app.shortcut.com/movableink/story/66417/movable-tailwind-config-security-error-shell-quote)