### PR TITLE
fix: only run release if certain files change

### DIFF
--- a/.github/workflows/release-it.yml
+++ b/.github/workflows/release-it.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  paths:
+    - 'config/*.js'
+    - 'package*.json'
   schedule:
     # Run the first of the month at 9:30am
     - cron: '30 9 1 * *'


### PR DESCRIPTION
Our release workflow runs every month no matter what, it shouldn't unless something changes.