### PR TITLE
fix(security): minimist must be ^1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "tailwindcss": "^2.1.1"
   },
   "resolutions": {
-    "shell-quote": "^1.7.3"
+    "shell-quote": "^1.7.3",
+    "minimist": "^1.2.6"
   },
   "engines": {
     "node": ">=10.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11343,10 +11343,10 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.1, minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+"minimist@npm:^1.2.6":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://www.cvedetails.com/cve/CVE-2021-44906/
https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795